### PR TITLE
feat: [canvasEvent.ts] fix Chinese input key conflicts

### DIFF
--- a/src/editor/core/event/CanvasEvent.ts
+++ b/src/editor/core/event/CanvasEvent.ts
@@ -306,7 +306,7 @@ export class CanvasEvent {
   public keydown(evt: KeyboardEvent) {
     const isReadonly = this.draw.isReadonly()
     const cursorPosition = this.position.getCursorPosition()
-    if (!cursorPosition) return
+    if (!cursorPosition || this.isCompositing) return
     const elementList = this.draw.getElementList()
     const position = this.position.getPositionList()
     const { index } = cursorPosition


### PR DESCRIPTION
当正在输入中文，“Backspace/Delete/Enter/Left/Right/Up/Down ....” 会与中文输入冲突，解决方案，当正在输入中文时，canvasEvent 不响应对应事件