### PR TITLE
fix: element not wrap when exceeding container width

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1096,6 +1096,16 @@ export class Draw {
           }
         }
         curRow.elementList.push(rowElement)
+        if (curRow.width >= innerWidth) {
+          rowList.push({
+            width: 0,
+            height: 0,
+            ascent: 0,
+            elementList: [],
+            startIndex: i + 1,
+            rowFlex: elementList?.[1]?.rowFlex,
+          })
+        }
       }
     }
     return rowList

--- a/src/editor/core/draw/particle/previewer/Previewer.ts
+++ b/src/editor/core/draw/particle/previewer/Previewer.ts
@@ -53,6 +53,8 @@ export class Previewer {
     resizerSelection.ondblclick = this._dblclick.bind(this)
     this.previewerContainer = null
     this.previewerImage = null
+    // 光标移动
+    this._keydown = this._keydown.bind(this)
   }
 
   private _createResizerDom(): IPreviewerCreateResult {
@@ -80,6 +82,15 @@ export class Previewer {
     resizerImageContainer.append(resizerImage)
     this.container.append(resizerImageContainer)
     return { resizerSelection, resizerHandleList, resizerImageContainer, resizerImage }
+  }
+
+  private _keydown(evt: KeyboardEvent){
+    const previewerIsFocus = this.resizerSelection.style.display === 'block'
+    if (previewerIsFocus) {
+      this.clearResizer()
+      this.draw.getCanvasEvent().keydown(evt)
+      document.removeEventListener('keydown', this._keydown)
+    }
   }
 
   private _mousedown(evt: MouseEvent) {
@@ -327,6 +338,8 @@ export class Previewer {
     this.curPosition = position
     this.width = this.curElement.width! * scale
     this.height = this.curElement.height! * scale
+    // 键盘移动
+    document.addEventListener('keydown',this._keydown)
   }
 
   public clearResizer() {


### PR DESCRIPTION
1、解决当前元素占完当前行时不换行问题，如：当一张图片占完一行的剩余空间时，再插入一张图片则无法显示。
2、选中图片时允许通过键盘取消选中图片并移动光标。