### PR TITLE
feat:add page number settings

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -271,6 +271,11 @@ export class Draw {
     return this.options.pageGap * this.options.scale
   }
 
+  public getPageNumberTop(): number {
+    const { pageNumber: { top }, scale } = this.options
+    return top * scale
+  }
+
   public getPageNumberBottom(): number {
     const { pageNumber: { bottom }, scale } = this.options
     return bottom * scale

--- a/src/editor/core/draw/frame/PageNumber.ts
+++ b/src/editor/core/draw/frame/PageNumber.ts
@@ -18,12 +18,12 @@ export class PageNumber {
   }
 
   public render(ctx: CanvasRenderingContext2D, pageNo: number) {
-    const { pageNumber: { size, font, color, rowFlex, numberType, format }, scale, pageMode } = this.options
+    const { pageNumber: { size, font, color, numberType, format, position, startAt }, scale, pageMode } = this.options
     // 处理页码格式
     let text = format
     const pageNoReg = new RegExp(FORMAT_PLACEHOLDER.PAGE_NO)
     if (pageNoReg.test(text)) {
-      const realPageNo = pageNo + 1
+      const realPageNo = startAt === 0 ? pageNo : pageNo + startAt
       const pageNoText = numberType === NumberType.CHINESE ? convertNumberToChinese(realPageNo) : `${realPageNo}`
       text = text.replace(pageNoReg, pageNoText)
     }
@@ -38,23 +38,66 @@ export class PageNumber {
     const height = pageMode === PageMode.CONTINUITY
       ? this.draw.getCanvasHeight(pageNo)
       : this.draw.getHeight()
+    const pageNumberTop = this.draw.getPageNumberTop()
     const pageNumberBottom = this.draw.getPageNumberBottom()
-    const y = height - pageNumberBottom
     ctx.save()
     ctx.fillStyle = color
     ctx.font = `${size * scale}px ${font}`
-    // 计算x位置-居左、居中、居右
-    let x = 0
     const margins = this.draw.getMargins()
+    const marginLeft = margins[3]
+    const marginRight = margins[1]
     const { width: textWidth } = ctx.measureText(text)
-    if (rowFlex === RowFlex.CENTER) {
-      x = (width - textWidth) / 2
-    } else if (rowFlex === RowFlex.RIGHT) {
-      x = width - textWidth - margins[1]
-    } else {
-      x = margins[3]
+    const centerPos = (width - textWidth) / 2
+    const rightPos = width - textWidth - marginRight
+    const bottomPos = height - pageNumberBottom
+    switch (position) {
+      case 'top-left':
+        ctx.fillText(text, marginLeft, pageNumberTop)
+        break
+      case 'top-center':
+        ctx.fillText(text, centerPos, pageNumberTop)
+        break
+      case 'top-right':
+        ctx.fillText(text, rightPos, pageNumberTop)
+        break
+      case 'bottom-left':
+        ctx.fillText(text, marginLeft, bottomPos)
+        break
+      case 'bottom-center':
+        ctx.fillText(text, centerPos, bottomPos)
+        break
+      case 'bottom-right':
+        ctx.fillText(text, rightPos, bottomPos)
+        break
+      case 'top-inner':
+        if (pageNo % 2 === 0) {
+          ctx.fillText(text, marginLeft, pageNumberTop)
+        } else {
+          ctx.fillText(text, rightPos, pageNumberTop)
+        }
+        break
+      case 'top-outer':
+        if (pageNo % 2 === 0) {
+          ctx.fillText(text, rightPos, pageNumberTop)
+        } else {
+          ctx.fillText(text, marginLeft, pageNumberTop)
+        }
+        break
+      case 'bottom-inner':
+        if (pageNo % 2 === 0) {
+          ctx.fillText(text, marginLeft, bottomPos)
+        } else {
+          ctx.fillText(text, rightPos, bottomPos)
+        }
+        break
+      case 'bottom-outer':
+        if (pageNo % 2 === 0) {
+          ctx.fillText(text, rightPos, bottomPos)
+        } else {
+          ctx.fillText(text, marginLeft, bottomPos)
+        }
+        break
     }
-    ctx.fillText(text, x, y)
     ctx.restore()
   }
 

--- a/src/editor/dataset/constant/PageNumber.ts
+++ b/src/editor/dataset/constant/PageNumber.ts
@@ -8,12 +8,15 @@ export const FORMAT_PLACEHOLDER = {
 }
 
 export const defaultPageNumberOption: Readonly<Required<IPageNumber>> = {
-  bottom: 60,
+  top: 30,
+  bottom: 30,
   size: 12,
   font: 'Yahei',
   color: '#000000',
   rowFlex: RowFlex.CENTER,
   format: FORMAT_PLACEHOLDER.PAGE_NO,
   numberType: NumberType.ARABIC,
+  position: 'bottom-center',
+  startAt: 1,
   disabled: false
 }

--- a/src/editor/interface/PageNumber.ts
+++ b/src/editor/interface/PageNumber.ts
@@ -1,7 +1,12 @@
 import { NumberType } from '../dataset/enum/Common'
 import { RowFlex } from '../dataset/enum/Row'
 
+type TopBottom = 'top' | 'bottom'
+type Side = 'left' | 'center' | 'right' | 'outer' | 'inner'
+export type IPageNumberPosition = `${TopBottom}-${Side}`
+
 export interface IPageNumber {
+  top?: number;
   bottom?: number;
   size?: number;
   font?: string;
@@ -9,5 +14,7 @@ export interface IPageNumber {
   rowFlex?: RowFlex;
   format?: string;
   numberType?: NumberType;
+  position?: IPageNumberPosition
+  startAt?: number;
   disabled?: boolean;
 }


### PR DESCRIPTION
Add a setting for the position of the page numbers, which can be altered by configuring the `position` option. Also, provide support for configuring the page numbers for double-sided printing, and allow users to configure the starting page number by `startAt`.