### PR TITLE
improve: cursor selection at the beginning of a line

### DIFF
--- a/src/editor/core/position/Position.ts
+++ b/src/editor/core/position/Position.ts
@@ -331,8 +331,10 @@ export class Position {
         const isHead = x < this.options.margins[3]
         // 是否在头部
         if (isHead) {
-          const headIndex = positionList.findIndex(p => p.pageNo === positionNo && p.rowNo === lastLetterList[j].rowNo)
-          curPositionIndex = ~headIndex ? headIndex - 1 : index
+          let headIndex = positionList.findIndex(p => p.pageNo === positionNo && p.rowNo === lastLetterList[j].rowNo)
+          //判断头部元素是否为空元素
+          headIndex = positionList[headIndex].value === ZERO ? headIndex : headIndex - 1
+          curPositionIndex = ~headIndex ? headIndex: index
         } else {
           curPositionIndex = index
         }

--- a/src/editor/core/position/Position.ts
+++ b/src/editor/core/position/Position.ts
@@ -331,10 +331,11 @@ export class Position {
         const isHead = x < this.options.margins[3]
         // 是否在头部
         if (isHead) {
-          let headIndex = positionList.findIndex(p => p.pageNo === positionNo && p.rowNo === lastLetterList[j].rowNo)
-          //判断头部元素是否为空元素
-          headIndex = positionList[headIndex].value === ZERO ? headIndex : headIndex - 1
-          curPositionIndex = ~headIndex ? headIndex: index
+          const headIndex = positionList.findIndex(p => p.pageNo === positionNo && p.rowNo === lastLetterList[j].rowNo)
+          // 头部元素为空元素时无需选中
+          curPositionIndex = ~headIndex
+            ? positionList[headIndex].value === ZERO ? headIndex : headIndex - 1
+            : index
         } else {
           curPositionIndex = index
         }


### PR DESCRIPTION
## 优化从右选至最左侧时总是选中上一行最右侧的空元素问题
### 优化前：
![image](https://github.com/Hufe921/canvas-editor/assets/43539608/a55cd0fa-6854-4a07-ba3a-26a8a34dcdfe)

### 优化后：
![image](https://github.com/Hufe921/canvas-editor/assets/43539608/26a47b78-b08c-4521-9468-459ba88477dc)
