### PR TITLE
fix: limit the maximun cursor offsetHeight to equal CURSOR_AGENT_HEIGHT

### DIFF
--- a/src/editor/core/cursor/Cursor.ts
+++ b/src/editor/core/cursor/Cursor.ts
@@ -1,4 +1,4 @@
-import { CURSOR_AGENT_HEIGHT } from '../../dataset/constant/Cursor'
+import { CURSOR_AGENT_OFFSET_HEIGHT } from '../../dataset/constant/Cursor'
 import { EDITOR_PREFIX } from '../../dataset/constant/Editor'
 import { MoveDirection } from '../../dataset/enum/Observer'
 import { DeepRequired } from '../../interface/Common'
@@ -121,12 +121,11 @@ export class Cursor {
       ? pageNo
       : this.draw.getPageNo()
     const preY = curPageNo * (height + pageGap)
-    // 增加1/4字体大小
-    let offsetHeight = metrics.height / 4
-    offsetHeight = offsetHeight > CURSOR_AGENT_HEIGHT
-      ? CURSOR_AGENT_HEIGHT
-      : offsetHeight
-    const cursorHeight = metrics.height + offsetHeight * 2
+    // 默认偏移高度
+    const defaultOffsetHeight = CURSOR_AGENT_OFFSET_HEIGHT * scale
+    // 增加1/4字体大小（最小为defaultOffsetHeight即默认偏移高度）
+    const increaseHeight = Math.min(metrics.height / 4, defaultOffsetHeight)
+    const cursorHeight = metrics.height + increaseHeight * 2
     const agentCursorDom = this.cursorAgent.getAgentCursorDom()
     if (isFocus) {
       setTimeout(() => {
@@ -138,16 +137,16 @@ export class Cursor {
     const descent =
       metrics.boundingBoxDescent < 0 ? 0 : metrics.boundingBoxDescent
     const cursorTop =
-      leftTop[1] + ascent + descent - (cursorHeight - offsetHeight) + preY
+      leftTop[1] + ascent + descent - (cursorHeight - increaseHeight) + preY
     const cursorLeft = hitLineStartIndex ? leftTop[0] : rightTop[0]
     agentCursorDom.style.left = `${cursorLeft}px`
     agentCursorDom.style.top = `${
-      cursorTop + cursorHeight - CURSOR_AGENT_HEIGHT * scale
+      cursorTop + cursorHeight - defaultOffsetHeight
     }px`
     // 模拟光标显示
     if (!isShow) return
     const isReadonly = this.draw.isReadonly()
-    this.cursorDom.style.width = `${width}px`
+    this.cursorDom.style.width = `${width * scale}px`
     this.cursorDom.style.backgroundColor = color
     this.cursorDom.style.left = `${cursorLeft}px`
     this.cursorDom.style.top = `${cursorTop}px`

--- a/src/editor/core/cursor/Cursor.ts
+++ b/src/editor/core/cursor/Cursor.ts
@@ -122,7 +122,10 @@ export class Cursor {
       : this.draw.getPageNo()
     const preY = curPageNo * (height + pageGap)
     // 增加1/4字体大小
-    const offsetHeight = metrics.height / 4
+    let offsetHeight = metrics.height / 4
+    offsetHeight = offsetHeight > CURSOR_AGENT_HEIGHT
+      ? CURSOR_AGENT_HEIGHT
+      : offsetHeight
     const cursorHeight = metrics.height + offsetHeight * 2
     const agentCursorDom = this.cursorAgent.getAgentCursorDom()
     if (isFocus) {

--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1194,7 +1194,7 @@ export class Draw {
         metrics.width = elementWidth
         metrics.height = elementHeight
         metrics.boundingBoxDescent = elementHeight
-        metrics.boundingBoxAscent = 0
+        metrics.boundingBoxAscent = -rowMargin
         // 表格分页处理(拆分表格)
         const height = this.getHeight()
         const marginHeight = this.getMainOuterHeight()

--- a/src/editor/dataset/constant/Cursor.ts
+++ b/src/editor/dataset/constant/Cursor.ts
@@ -1,6 +1,6 @@
 import { ICursorOption } from '../../interface/Cursor'
 
-export const CURSOR_AGENT_HEIGHT = 12
+export const CURSOR_AGENT_OFFSET_HEIGHT = 12
 
 export const defaultCursorOption: Readonly<Required<ICursorOption>> = {
   width: 1,


### PR DESCRIPTION
- **问题**
图片类型元素光标高度offsetHeight也为图片类型元素高度1/4，图片高度比较高时光标高度太高
<img width="807" alt="snapcut" src="https://github.com/Hufe921/canvas-editor/assets/10184923/fd2d7e70-57dc-4898-9a1a-266f64527b54">



- **解决方案**
光标offsetHeight最大值不超过 CURSOR_AGENT_HEIGHT = 12

<img width="810" alt="snapcut-fixed" src="https://github.com/Hufe921/canvas-editor/assets/10184923/82bdcae5-579e-4d42-b268-ca099014400f">

