### PR TITLE
fix: multiple empty lists render error in first row

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1414,7 +1414,7 @@ export class Draw {
         if (
           curRow.startIndex === 0 &&
           curRow.elementList.length === 1 &&
-          (INLINE_ELEMENT_TYPE.includes(element.type!) || element.listId)
+          INLINE_ELEMENT_TYPE.includes(element.type!)
         ) {
           curRow.height = defaultBasicRowMarginHeight
         }

--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1823,7 +1823,7 @@ export class Draw {
       this.waterMark.render(ctx)
     }
     // 绘制空白占位符
-    if (this.elementList.length <= 1) {
+    if (this.elementList.length <= 1 && !this.elementList[0]?.listId) {
       this.placeholder.render(ctx)
     }
   }


### PR DESCRIPTION
**问题：**
 - 第一行为空列表时依然渲染了placeholder
![placeholder-error](https://github.com/Hufe921/canvas-editor/assets/10184923/68442e7f-f7c6-4de0-a157-88a60af9da93)

 - 第一行空列表元素时，高度设置为`defaultBasicRowMarginHeight = 8` 行高太低
![list-row-height-error](https://github.com/Hufe921/canvas-editor/assets/10184923/579c64c9-fae3-4150-b70d-4ddd763939d0)
