### PR TITLE
修复文字属性变化后提前渲染  导致后面渲染的高亮背景覆盖在文字上

### DIFF
--- a/src/editor/core/draw/particle/TextParticle.ts
+++ b/src/editor/core/draw/particle/TextParticle.ts
@@ -11,7 +11,7 @@ export interface IMeasureWordResult {
 }
 
 export class TextParticle {
-  private textArr: { value: string; X: number, Y: number, style: string, color: string }[]
+  private textArr: { value: string; X: number, Y: number, style: string, color?: string }[]
   private draw: Draw
   private options: DeepRequired<IEditorOption>
   private ctx: CanvasRenderingContext2D

--- a/src/editor/core/draw/particle/TextParticle.ts
+++ b/src/editor/core/draw/particle/TextParticle.ts
@@ -11,7 +11,7 @@ export interface IMeasureWordResult {
 }
 
 export class TextParticle {
-  private textArr: { value: string; X: number, Y: number, style: string, color?: string }[]
+  private textArr: { value: string; X: number, Y: number, style: string, color: string }[]
   private draw: Draw
   private options: DeepRequired<IEditorOption>
   private ctx: CanvasRenderingContext2D

--- a/src/editor/core/draw/particle/TextParticle.ts
+++ b/src/editor/core/draw/particle/TextParticle.ts
@@ -133,13 +133,13 @@ export class TextParticle {
 
   private _render() {
     if (!this.textArr.length ) return
+    this.ctx.save()
     for(const item of this.textArr){
       if(!item.value || !~item.X || !~item.Y) continue
-      this.ctx.save()
       this.ctx.font = item.style
       this.ctx.fillStyle = item.color || this.options.defaultColor
       this.ctx.fillText(item.value, item.X, item.Y)
-      this.ctx.restore()
     }
+    this.ctx.restore()
   }
 }


### PR DESCRIPTION

![NnLeCKAioT](https://github.com/Hufe921/canvas-editor/assets/70557462/edb57a81-aae6-4edb-8f4e-7851a6e8e2a2)


**上方前的字体明显被背景覆盖导致模糊了**

**修复完状态如下：**

![image](https://github.com/Hufe921/canvas-editor/assets/70557462/acafbd44-0cd1-4eb7-8a1e-d6696a915429)
