### PR TITLE
fix: 清洁模式和打印模式下显示了换行符

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1891,6 +1891,8 @@ export class Draw {
         // 换行符绘制
         if (
           isDrawLineBreak &&
+          !isPrintMode &&
+          this.mode !== EditorMode.CLEAN &&
           !curRow.isWidthNotEnough &&
           j === curRow.elementList.length - 1
         ) {


### PR DESCRIPTION
修改之后换行符和分页符一样不在清洁模式和打印模式显示