### PR TITLE
feat: add support for disabling header on specific pages

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1080,7 +1080,8 @@ export class Draw {
     pageComponentData.forEach(data => {
       if (!data) return
       formatElementList(data, {
-        editorOptions: this.options
+        editorOptions: this.options,
+        isForceCompensation: true
       })
     })
     this.setEditorData({

--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -2255,7 +2255,7 @@ export class Draw {
     })
     if (this.getIsPagingMode()) {
       // 绘制页眉
-      if (!header.disabled) {
+      if (!header.disabled  && !header.disabledPages.includes(pageNo)) {
         this.header.render(ctx, pageNo)
       }
       // 绘制页码

--- a/src/editor/core/draw/control/Control.ts
+++ b/src/editor/core/draw/control/Control.ts
@@ -892,7 +892,8 @@ export class Control {
       const elementList = zipElementList(pageComponentData[pageComponentKey]!)
       pageComponentData[pageComponentKey] = elementList
       formatElementList(elementList, {
-        editorOptions: this.options
+        editorOptions: this.options,
+        isForceCompensation: true
       })
     }
     this.draw.setEditorData(pageComponentData)

--- a/src/editor/core/draw/frame/Placeholder.ts
+++ b/src/editor/core/draw/frame/Placeholder.ts
@@ -84,7 +84,8 @@ export class Placeholder {
       }
     ]
     formatElementList(this.elementList, {
-      editorOptions: this.options
+      editorOptions: this.options,
+      isForceCompensation: true
     })
     // 计算
     this._compute()

--- a/src/editor/dataset/constant/Header.ts
+++ b/src/editor/dataset/constant/Header.ts
@@ -4,5 +4,6 @@ import { MaxHeightRatio } from '../enum/Common'
 export const defaultHeaderOption: Readonly<Required<IHeader>> = {
   top: 30,
   maxHeightRadio: MaxHeightRatio.HALF,
-  disabled: false
+  disabled: false,
+  disabledPages: []
 }

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -89,7 +89,8 @@ export default class Editor {
     ]
     pageComponentData.forEach(elementList => {
       formatElementList(elementList, {
-        editorOptions
+        editorOptions,
+        isForceCompensation: true
       })
     })
     // 监听

--- a/src/editor/interface/Header.ts
+++ b/src/editor/interface/Header.ts
@@ -4,4 +4,5 @@ export interface IHeader {
   top?: number
   maxHeightRadio?: MaxHeightRatio
   disabled?: boolean
+  disabledPages?:number[]
 }

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -65,7 +65,8 @@ export function unzipElementList(elementList: IElement[]): IElement[] {
 }
 
 interface IFormatElementListOption {
-  isHandleFirstElement?: boolean
+  isHandleFirstElement?: boolean // 根据上下文确定首字符处理逻辑（处理首字符补偿）
+  isForceCompensation?: boolean // 强制补偿字符
   editorOptions: DeepRequired<IEditorOption>
 }
 
@@ -73,17 +74,19 @@ export function formatElementList(
   elementList: IElement[],
   options: IFormatElementListOption
 ) {
-  const { isHandleFirstElement, editorOptions } = <IFormatElementListOption>{
-    isHandleFirstElement: true,
-    ...options
-  }
+  const {
+    isHandleFirstElement = true,
+    isForceCompensation = false,
+    editorOptions
+  } = options
   const startElement = elementList[0]
   // 非首字符零宽节点文本元素则补偿-列表元素内部会补偿此处忽略
   if (
-    isHandleFirstElement &&
-    startElement?.type !== ElementType.LIST &&
-    ((startElement?.type && startElement.type !== ElementType.TEXT) ||
-      !START_LINE_BREAK_REG.test(startElement?.value))
+    isForceCompensation ||
+    (isHandleFirstElement &&
+      startElement?.type !== ElementType.LIST &&
+      ((startElement?.type && startElement.type !== ElementType.TEXT) ||
+        !START_LINE_BREAK_REG.test(startElement?.value)))
   ) {
     elementList.unshift({
       value: ZERO
@@ -100,7 +103,8 @@ export function formatElementList(
       const valueList = el.valueList || []
       formatElementList(valueList, {
         ...options,
-        isHandleFirstElement: false
+        isHandleFirstElement: false,
+        isForceCompensation: false
       })
       // 追加节点
       if (valueList.length) {
@@ -134,7 +138,8 @@ export function formatElementList(
       const valueList = el.valueList || []
       formatElementList(valueList, {
         ...options,
-        isHandleFirstElement: true
+        isHandleFirstElement: true,
+        isForceCompensation: false
       })
       // 追加节点
       if (valueList.length) {
@@ -170,7 +175,8 @@ export function formatElementList(
             td.id = tdId
             formatElementList(td.value, {
               ...options,
-              isHandleFirstElement: true
+              isHandleFirstElement: true,
+              isForceCompensation: false
             })
             for (let v = 0; v < td.value.length; v++) {
               const value = td.value[v]
@@ -385,7 +391,8 @@ export function formatElementList(
           }
           formatElementList(valueList, {
             ...options,
-            isHandleFirstElement: false
+            isHandleFirstElement: false,
+            isForceCompensation: false
           })
           for (let v = 0; v < valueList.length; v++) {
             const element = valueList[v]


### PR DESCRIPTION
#778 
 - Added a new configuration option `disabledPages` to the `IHeader` interface.
 - The `disabledPages` array allows disabling the header on specific pages while maintaining the header on others.
 - Updated the header rendering logic to skip rendering on pages listed in `disabledPages