### PR TITLE
Fixed cursor positioning at control location

### DIFF
--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -1828,13 +1828,17 @@ export class CommandAdapt {
         }
         if (element?.controlId !== controlId) continue
         let curIndex = i - 1
-        if (isLocationAfter) {
-          curIndex -= 1
-          if (
-            element.controlComponent !== ControlComponent.PLACEHOLDER &&
-            element.controlComponent !== ControlComponent.POSTFIX
-          ) {
-            continue
+        if (options?.position) {
+          if (isLocationAfter) {
+            curIndex = elementList.length - 1
+            if (
+              element.controlComponent !== ControlComponent.PLACEHOLDER &&
+              element.controlComponent !== ControlComponent.POSTFIX
+            ) {
+              continue
+            }
+          } else {
+            curIndex -= 1
           }
         }
         return {


### PR DESCRIPTION
When executing instance.command.executeLocationControl('...', {position: 'bofere/after'), the cursor is always positioned inside the control.


https://github.com/user-attachments/assets/cc0d7b88-e3dc-4a71-b13e-4e6361dd8007


Now it is positioned correctly according to the parameter, if nothing is informed, it is positioned inside the control


https://github.com/user-attachments/assets/a5a0ca65-ff66-409f-a16f-71fd2e2f5d41

