### PR TITLE
feat: option to disable editing header / footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 .DS_Store
 dist

--- a/docs/en/guide/option.md
+++ b/docs/en/guide/option.md
@@ -1,6 +1,6 @@
 # Configuration
 
-## How to Use ?
+## How to Use?
 
 ```javascript
 import Editor from "@hufe921/canvas-editor"

--- a/docs/en/guide/option.md
+++ b/docs/en/guide/option.md
@@ -54,7 +54,7 @@ interface IEditorOption {
   historyMaxRecordCount?: number // History (undo redo) maximum number of records. default: 100
   printPixelRatio?: number // Print the pixel ratio (larger values are clearer, but larger sizes). default: 3
   maskMargin?: IMargin // Masking margins above the editor（for example: menu bar, bottom toolbar）。default: [0, 0, 0, 0]
-  letterClass? string[] // Alphabet class supported by typesetting. default: a-zA-Z. Built-in alternative alphabet class: LETTER_CLASS
+  letterClass?: string[] // Alphabet class supported by typesetting. default: a-zA-Z. Built-in alternative alphabet class: LETTER_CLASS
   contextMenuDisableKeys?: string[] // Disable context menu keys. default: []
   scrollContainerSelector?: string // scroll container selector. default: document
   wordBreak?: WordBreak // Word and punctuation breaks: No punctuation in the first line of the BREAK_WORD &The word is not split, and the line is folded after BREAK_ALL full according to the width of the character. default: BREAK_WORD
@@ -93,6 +93,7 @@ interface IHeader {
   top?: number // Size from the top of the page.default: 30
   maxHeightRadio?: MaxHeightRatio // Occupies the maximum height ratio of the page.default: HALF
   disabled?: boolean // Whether to disable
+  editable?: boolean // Disable the header content from being edited
 }
 ```
 
@@ -103,6 +104,7 @@ interface IFooter {
   bottom?: number // The size from the bottom of the page.default: 30
   maxHeightRadio?: MaxHeightRatio // Occupies the maximum height ratio of the page.default: HALF
   disabled?: boolean // Whether to disable
+  editable?: boolean // Disable the footer content from being edited
 }
 ```
 

--- a/docs/guide/option.md
+++ b/docs/guide/option.md
@@ -93,6 +93,7 @@ interface IHeader {
   top?: number // 距离页面顶部大小。默认：30
   maxHeightRadio?: MaxHeightRatio // 占页面最大高度比。默认：HALF
   disabled?: boolean // 是否禁用
+  editable?: boolean // 禁止编辑标题内容
 }
 ```
 
@@ -103,6 +104,7 @@ interface IFooter {
   bottom?: number // 距离页面底部大小。默认：30
   maxHeightRadio?: MaxHeightRatio // 占页面最大高度比。默认：HALF
   disabled?: boolean // 是否禁用
+  editable?: boolean // 禁止编辑页脚内容
 }
 ```
 

--- a/src/editor/core/event/handlers/click.ts
+++ b/src/editor/core/event/handlers/click.ts
@@ -108,7 +108,6 @@ function dblclick(host: CanvasEvent, evt: MouseEvent) {
     x: evt.offsetX,
     y: evt.offsetY
   })
-
   // 图片预览
   if (positionContext.isImage && positionContext.isDirectHit) {
     draw.getPreviewer().render()

--- a/src/editor/core/event/handlers/click.ts
+++ b/src/editor/core/event/handlers/click.ts
@@ -4,6 +4,7 @@ import { NUMBER_LIKE_REG } from '../../../dataset/constant/Regular'
 import { ElementType } from '../../../dataset/enum/Element'
 import { IRange } from '../../../interface/Range'
 import { CanvasEvent } from '../CanvasEvent'
+import { EditorZone } from '../../../dataset/enum/Editor'
 
 // 通过分词器获取单词所在选区
 function getWordRangeBySegmenter(host: CanvasEvent): IRange | null {
@@ -104,10 +105,20 @@ function getWordRangeByCursor(host: CanvasEvent): IRange | null {
 function dblclick(host: CanvasEvent, evt: MouseEvent) {
   const draw = host.getDraw()
   const position = draw.getPosition()
+  const options = draw.getOptions()
   const positionContext = position.getPositionByXY({
     x: evt.offsetX,
     y: evt.offsetY
   })
+
+  // Disable double click if the position is in Header or Footer and the zone is not editable
+  if(positionContext.zone === EditorZone.HEADER && !options.header.editable) {
+    return
+  }
+  if(positionContext.zone === EditorZone.FOOTER && !options.footer.editable) {
+    return
+  }
+
   // 图片预览
   if (positionContext.isImage && positionContext.isDirectHit) {
     draw.getPreviewer().render()

--- a/src/editor/core/event/handlers/click.ts
+++ b/src/editor/core/event/handlers/click.ts
@@ -4,7 +4,6 @@ import { NUMBER_LIKE_REG } from '../../../dataset/constant/Regular'
 import { ElementType } from '../../../dataset/enum/Element'
 import { IRange } from '../../../interface/Range'
 import { CanvasEvent } from '../CanvasEvent'
-import { EditorZone } from '../../../dataset/enum/Editor'
 
 // 通过分词器获取单词所在选区
 function getWordRangeBySegmenter(host: CanvasEvent): IRange | null {
@@ -105,19 +104,10 @@ function getWordRangeByCursor(host: CanvasEvent): IRange | null {
 function dblclick(host: CanvasEvent, evt: MouseEvent) {
   const draw = host.getDraw()
   const position = draw.getPosition()
-  const options = draw.getOptions()
   const positionContext = position.getPositionByXY({
     x: evt.offsetX,
     y: evt.offsetY
   })
-
-  // Disable double click if the position is in Header or Footer and the zone is not editable
-  if(positionContext.zone === EditorZone.HEADER && !options.header.editable) {
-    return
-  }
-  if(positionContext.zone === EditorZone.FOOTER && !options.footer.editable) {
-    return
-  }
 
   // 图片预览
   if (positionContext.isImage && positionContext.isDirectHit) {

--- a/src/editor/core/zone/Zone.ts
+++ b/src/editor/core/zone/Zone.ts
@@ -48,6 +48,13 @@ export class Zone {
   }
 
   public setZone(payload: EditorZone) {
+    const { header, footer } = this.options
+    if (
+      (!header.editable && payload === EditorZone.HEADER) ||
+      (!footer.editable && payload === EditorZone.FOOTER)
+    ) {
+      return
+    }
     if (this.currentZone === payload) return
     this.currentZone = payload
     this.draw.getRange().clearRange()

--- a/src/editor/dataset/constant/Footer.ts
+++ b/src/editor/dataset/constant/Footer.ts
@@ -4,5 +4,6 @@ import { MaxHeightRatio } from '../enum/Common'
 export const defaultFooterOption: Readonly<Required<IFooter>> = {
   bottom: 30,
   maxHeightRadio: MaxHeightRatio.HALF,
-  disabled: false
+  disabled: false,
+  editable: true
 }

--- a/src/editor/dataset/constant/Header.ts
+++ b/src/editor/dataset/constant/Header.ts
@@ -4,5 +4,6 @@ import { MaxHeightRatio } from '../enum/Common'
 export const defaultHeaderOption: Readonly<Required<IHeader>> = {
   top: 30,
   maxHeightRadio: MaxHeightRatio.HALF,
-  disabled: false
+  disabled: false,
+  editable: true
 }

--- a/src/editor/interface/Footer.ts
+++ b/src/editor/interface/Footer.ts
@@ -4,4 +4,5 @@ export interface IFooter {
   bottom?: number
   maxHeightRadio?: MaxHeightRatio
   disabled?: boolean
+  editable?: boolean
 }

--- a/src/editor/interface/Header.ts
+++ b/src/editor/interface/Header.ts
@@ -4,4 +4,5 @@ export interface IHeader {
   top?: number
   maxHeightRadio?: MaxHeightRatio
   disabled?: boolean
+  editable?: boolean
 }


### PR DESCRIPTION
This solves the requirement of enabling the editor main for final users and prevent then to edit headers and footers that are pre-determined by template creator.