### PR TITLE
feat: get cursor position

### DIFF
--- a/docs/en/guide/command-get.md
+++ b/docs/en/guide/command-get.md
@@ -53,6 +53,16 @@ Usage:
 const wordCount = await instance.command.getWordCount()
 ```
 
+## getCursorPosition
+
+Feature: Get cursor position with coordinates
+
+Usage:
+
+```javascript
+const range = instance.command.getCursorPosition()
+```
+
 ## getRange
 
 Feature: Get range

--- a/docs/guide/command-get.md
+++ b/docs/guide/command-get.md
@@ -53,6 +53,16 @@ const editorOption = await instance.command.getOptions()
 const wordCount = await instance.command.getWordCount()
 ```
 
+## getCursorPosition
+
+功能: 获取光标位置坐标
+
+用法:
+
+```javascript
+const range = instance.command.getCursorPosition()
+```
+
 ## getRange
 
 功能：获取选区

--- a/src/editor/core/command/Command.ts
+++ b/src/editor/core/command/Command.ts
@@ -103,6 +103,7 @@ export class Command {
   public getHTML: CommandAdapt['getHTML']
   public getText: CommandAdapt['getText']
   public getWordCount: CommandAdapt['getWordCount']
+  public getCursorPosition: CommandAdapt['getCursorPosition']
   public getRange: CommandAdapt['getRange']
   public getRangeText: CommandAdapt['getRangeText']
   public getRangeContext: CommandAdapt['getRangeContext']
@@ -223,6 +224,7 @@ export class Command {
     this.getHTML = adapt.getHTML.bind(adapt)
     this.getText = adapt.getText.bind(adapt)
     this.getWordCount = adapt.getWordCount.bind(adapt)
+    this.getCursorPosition = adapt.getCursorPosition.bind(adapt)
     this.getRange = adapt.getRange.bind(adapt)
     this.getRangeText = adapt.getRangeText.bind(adapt)
     this.getRangeContext = adapt.getRangeContext.bind(adapt)

--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -1360,6 +1360,10 @@ export class CommandAdapt {
     return this.workerManager.getWordCount()
   }
 
+  public getCursorPosition(): IElementPosition | null {
+    return this.position.getCursorPosition()
+  }
+
   public getRange(): IRange {
     return deepClone(this.range.getRange())
   }


### PR DESCRIPTION
This feature solves the problem of developer to be able to open custom tooltips on cursor coordinates in the editor container by command

<img width="430" alt="image" src="https://github.com/user-attachments/assets/6accdb85-c06a-45f8-8a89-e4b91d0b3a4f">
