### PR TITLE
Solves the problem of switching assignments within cells using arrow keys

### DIFF
--- a/src/editor/core/event/handlers/keydown/left.ts
+++ b/src/editor/core/event/handlers/keydown/left.ts
@@ -129,7 +129,7 @@ export function left(evt: KeyboardEvent, host: CanvasEvent) {
                 tdIndex: preTdIndex,
                 tdId: preTd.id,
                 trId: preTr.id,
-                tableId: element.id
+                tableId: element.tableId
               })
               anchorStartIndex = preTd.value.length - 1
               anchorEndIndex = anchorStartIndex

--- a/src/editor/core/event/handlers/keydown/right.ts
+++ b/src/editor/core/event/handlers/keydown/right.ts
@@ -130,7 +130,7 @@ export function right(evt: KeyboardEvent, host: CanvasEvent) {
                 tdIndex: nextTdIndex,
                 tdId: preTd.id,
                 trId: preTr.id,
-                tableId: element.id
+                tableId: element.tableId
               })
               anchorStartIndex = 0
               anchorEndIndex = anchorStartIndex

--- a/src/editor/core/event/handlers/keydown/updown.ts
+++ b/src/editor/core/event/handlers/keydown/updown.ts
@@ -124,8 +124,8 @@ export function updown(evt: KeyboardEvent, host: CanvasEvent) {
           index,
           trIndex: preTrIndex,
           tdIndex: preTdIndex,
-          tdId: preTr.id,
-          trId: preTd.id,
+          tdId: preTd.id,
+          trId: preTr.id,
           tableId
         })
         anchorStartIndex = preTd.value.length - 1
@@ -173,8 +173,8 @@ export function updown(evt: KeyboardEvent, host: CanvasEvent) {
           index,
           trIndex: nexTrIndex,
           tdIndex: nextTdIndex,
-          tdId: nextTr.id,
-          trId: nextTd.id,
+          tdId: nextTd.id,
+          trId: nextTr.id,
           tableId
         })
         anchorStartIndex = nextTd.value.length - 1


### PR DESCRIPTION
### 问题
我在做render和computeRowList两个核心渲染函数优化时，
了解到需要重新计算几何信息的情况下，渲染引擎的宏观过程是：
1. 将每个元素计算成每一行的几何信息
2. 再将每一行的几何信息分给每一页

所以对于每行元素的计算，在表格中进行操作和表格外进行操作，表格和外部是互不影响的，而本库中又有positionContext，可以拿到当前的位置上下文是在表格中的某个td还是在表格外，所以在computeRowList中（排除初始化渲染的情况），对表格计算进行限制：
1. render中先获取位置上下文，获取tableId，tdId，传给computeRowList
2. 在遍历元素时，对TABLE类型的元素进行限制，如果非初始化，以及当前位置上下文不在对应的表格以及td内，就复用之前存起来的rowList以及metrics，同时tableId会存在map中，以便处理新增的table和删除的table，包括跨页表格的处理

为了完成我目前的最大的文档的业务这个改动已经算是优化不少了，但是我知道这个改动并不是对于这个库最优的解。

**这个PR提交是因为我在调试这个渲染引擎的改动时，在使用上下左右键切换单元格再输入时，发现渲染失败，经查实是在上下左右键切换单元格后，setPositionContext方法中，相关的tableId，trId，tdId赋值错误，所以提交了这个PR，修复这相关的赋值问题**