### PR TITLE
feat: 表单模式下Date控件、Select控件,点击文档中空白处可被销毁

### DIFF
--- a/src/editor/core/draw/control/Control.ts
+++ b/src/editor/core/draw/control/Control.ts
@@ -272,7 +272,6 @@ export class Control {
   }
 
   public initControl() {
-    const isReadonly = this.draw.isReadonly()
     const elementList = this.getElementList()
     const range = this.getRange()
     const element = elementList[range.startIndex]
@@ -294,8 +293,9 @@ export class Control {
     }
     // 销毁旧激活控件
     this.destroyControl()
-    if (isReadonly) return
     // 激活控件
+    const isReadonly = this.draw.isReadonly()
+    if (isReadonly) return
     const control = element.control!
     if (control.type === ControlType.TEXT) {
       this.activeControl = new TextControl(element, this)

--- a/src/editor/core/draw/control/Control.ts
+++ b/src/editor/core/draw/control/Control.ts
@@ -273,7 +273,6 @@ export class Control {
 
   public initControl() {
     const isReadonly = this.draw.isReadonly()
-    if (isReadonly) return
     const elementList = this.getElementList()
     const range = this.getRange()
     const element = elementList[range.startIndex]
@@ -295,6 +294,7 @@ export class Control {
     }
     // 销毁旧激活控件
     this.destroyControl()
+    if (isReadonly) return
     // 激活控件
     const control = element.control!
     if (control.type === ControlType.TEXT) {


### PR DESCRIPTION
在表单模式下,Select控件 或 Date控件处于激活中时,点击文档中空白处无法关闭弹窗.会给用户造成一定的交互错觉,同时也缩小了弹窗可关闭的范围. 

触发时机: Select控件 或 Date控件激活时,并且下次点击的行是以控件为结尾.

具体原因为: 在表单模式下, 通过 getIsRangeWithinControl 函数进行判断是否为 isReadonly . 而 getIsRangeWithinControl 在满足触发时机的情况下, 返回 false. 

具体情况如下视频: 

https://github.com/user-attachments/assets/4005090b-9741-408a-8a7b-36e87b4a4a6b

