### PR TITLE
fix: insert control in area element didnt clone area element attr

### DIFF
--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -2114,7 +2114,7 @@ export class CommandAdapt {
       ...TABLE_CONTEXT_ATTR,
       ...EDITOR_ROW_ATTR,
       ...LIST_CONTEXT_ATTR,
-      ...AREA_CONTEXT_ATTR,
+      ...AREA_CONTEXT_ATTR
     ]
     cloneProperty<IElement>(cloneAttr, copyElement, cloneElement)
     // 插入控件
@@ -2262,7 +2262,8 @@ export class CommandAdapt {
     const cloneAttr = [
       ...TABLE_CONTEXT_ATTR,
       ...EDITOR_ROW_ATTR,
-      ...LIST_CONTEXT_ATTR
+      ...LIST_CONTEXT_ATTR,
+      ...AREA_CONTEXT_ATTR
     ]
     cloneElement.valueList?.forEach(valueItem => {
       cloneProperty<IElement>(cloneAttr, copyElement, valueItem)

--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -1,5 +1,6 @@
 import { NBSP, WRAP, ZERO } from '../../dataset/constant/Common'
 import {
+  AREA_CONTEXT_ATTR,
   EDITOR_ELEMENT_STYLE_ATTR,
   EDITOR_ROW_ATTR,
   LIST_CONTEXT_ATTR,
@@ -2112,7 +2113,8 @@ export class CommandAdapt {
     const cloneAttr = [
       ...TABLE_CONTEXT_ATTR,
       ...EDITOR_ROW_ATTR,
-      ...LIST_CONTEXT_ATTR
+      ...LIST_CONTEXT_ATTR,
+      ...AREA_CONTEXT_ATTR,
     ]
     cloneProperty<IElement>(cloneAttr, copyElement, cloneElement)
     // 插入控件


### PR DESCRIPTION
插入控件时赋值区域内元素属性