### PR TITLE
fix: Incorrect location when the location context is in the table

### DIFF
--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -1916,6 +1916,9 @@ export class CommandAdapt {
   }
 
   public locationCatalog(titleId: string) {
+    this.position.setPositionContext({
+      isTable: false
+    })
     const elementList = this.draw.getMainElementList()
     let newIndex = -1
     for (let e = 0; e < elementList.length; e++) {

--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -1916,10 +1916,7 @@ export class CommandAdapt {
   }
 
   public locationCatalog(titleId: string) {
-    this.position.setPositionContext({
-      isTable: false
-    })
-    const elementList = this.draw.getMainElementList()
+    const elementList = this.draw.getOriginalMainElementList()
     let newIndex = -1
     for (let e = 0; e < elementList.length; e++) {
       const element = elementList[e]
@@ -1932,6 +1929,9 @@ export class CommandAdapt {
       }
     }
     if (!~newIndex) return
+    this.position.setPositionContext({
+      isTable: false
+    })
     this.range.setRange(newIndex, newIndex)
     this.draw.render({
       curIndex: newIndex,


### PR DESCRIPTION
当定位目录时，位置上下文在表格中时，获取到的元素是表格中的元素，导致定位不准。
所以在定位目录的命令中，强制将上下文指定为全局上下文，获取全局顶层元素，使定位准确。