### PR TITLE
fix: nav index not clear caused error after replace

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1221,6 +1221,8 @@ window.onload = function () {
       const replaceValue = replaceInputDom.value
       if (searchValue && replaceValue && searchValue !== replaceValue) {
         instance.command.executeReplace(replaceValue)
+        instance.command.executeSearch(searchInputDom.value || null)
+        setSearchResult()
       }
     }
   searchCollapseDom.querySelector<HTMLDivElement>('.arrow-left')!.onclick =


### PR DESCRIPTION
![1212_03](https://github.com/user-attachments/assets/d553abe6-261e-4bb3-9c4d-d1875bc905f1)
在替换完成后，因为控件placeholder中的值仍旧保留，新的match list数据导致nav_prev或者nav_next的过程直接采用之前的nav_index,当nav_index大于match_list length,导致报错。