### PR TITLE
feat: 主线合并支持pdf渲染层 #374

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "cypress": "13.6.0",
     "cypress-file-upload": "^5.0.8",
     "eslint": "7.32.0",
+    "jspdf": "^2.5.2",
     "simple-git-hooks": "^2.8.1",
     "typescript": "4.9.5",
     "vite": "^2.4.2",

--- a/pdf.html
+++ b/pdf.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/png" href="favicon.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>canvas-editor</title>
+</head>
+
+<body>
+  <div id="app">
+    <div class="menu" editor-component="menu">
+      <div class="menu-item">
+        <div class="menu-item__undo">
+          <i></i>
+        </div>
+        <div class="menu-item__redo">
+          <i></i>
+        </div>
+        <div class="menu-item__painter" title="格式刷(双击可连续使用)">
+          <i></i>
+        </div>
+        <div class="menu-item__format" title="清除格式">
+          <i></i>
+        </div>
+      </div>
+      <div class="menu-divider"></div>
+      <div class="menu-item">
+        <div class="menu-item__font">
+          <span class="select" title="字体">微软雅黑</span>
+          <div class="options">
+            <ul>
+              <li data-family="Microsoft YaHei" style="font-family:'Microsoft YaHei';">微软雅黑</li>
+              <li data-family="华文宋体" style="font-family:'华文宋体';">华文宋体</li>
+              <li data-family="华文黑体" style="font-family:'华文黑体';">华文黑体</li>
+<!--              <li data-family="华文仿宋" style="font-family:'华文仿宋';">华文仿宋</li>-->
+              <li data-family="sim-fang" style="font-family:'华文仿宋';">华文仿宋</li>
+              <li data-family="华文楷体" style="font-family:'华文楷体';">华文楷体</li>
+              <li data-family="华文琥珀" style="font-family:'华文琥珀';">华文琥珀</li>
+              <li data-family="华文楷体" style="font-family:'华文楷体';">华文楷体</li>
+              <li data-family="华文隶书" style="font-family:'华文隶书';">华文隶书</li>
+              <li data-family="华文新魏" style="font-family:'华文新魏';">华文新魏</li>
+              <li data-family="华文行楷" style="font-family:'华文行楷';">华文行楷</li>
+              <li data-family="华文中宋" style="font-family:'华文中宋';">华文中宋</li>
+              <li data-family="华文彩云" style="font-family:'华文彩云';">华文彩云</li>
+              <li data-family="Arial" style="font-family:'Arial';">Arial</li>
+              <li data-family="Segoe UI" style="font-family:'Segoe UI';">Segoe UI</li>
+              <li data-family="Ink Free" style="font-family:'Ink Free';">Ink Free</li>
+              <li data-family="Fantasy" style="font-family:'Fantasy';">Fantasy</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__size">
+          <span class="select" title="字体">小四</span>
+          <div class="options">
+            <ul>
+              <li data-size="56">初号</li>
+              <li data-size="48">小初</li>
+              <li data-size="34">一号</li>
+              <li data-size="32">小一</li>
+              <li data-size="29">二号</li>
+              <li data-size="24">小二</li>
+              <li data-size="21">三号</li>
+              <li data-size="20">小三</li>
+              <li data-size="18">四号</li>
+              <li data-size="16">小四</li>
+              <li data-size="14">五号</li>
+              <li data-size="12">小五</li>
+              <li data-size="10">六号</li>
+              <li data-size="8">小六</li>
+              <li data-size="7">七号</li>
+              <li data-size="6">八号</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__size-add">
+          <i></i>
+        </div>
+        <div class="menu-item__size-minus">
+          <i></i>
+        </div>
+        <div class="menu-item__bold">
+          <i></i>
+        </div>
+        <div class="menu-item__italic">
+          <i></i>
+        </div>
+        <div class="menu-item__underline">
+          <i></i>
+          <span class="select"></span>
+          <div class="options">
+            <ul>
+              <li data-decoration-style='solid'>
+                <i></i>
+              </li>
+              <li data-decoration-style='double'>
+                <i></i>
+              </li>
+              <li data-decoration-style='dashed'>
+                <i></i>
+              </li>
+              <li data-decoration-style='dotted'>
+                <i></i>
+              </li>
+              <li data-decoration-style='wavy'>
+                <i></i>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__strikeout" title="删除线(Ctrl+Shift+X)">
+          <i></i>
+        </div>
+        <div class="menu-item__superscript">
+          <i></i>
+        </div>
+        <div class="menu-item__subscript">
+          <i></i>
+        </div>
+        <div class="menu-item__color" title="字体颜色">
+          <i></i>
+          <span></span>
+          <input type="color" id="color" />
+        </div>
+        <div class="menu-item__highlight" title="高亮">
+          <i></i>
+          <span></span>
+          <input type="color" id="highlight">
+        </div>
+      </div>
+      <div class="menu-divider"></div>
+      <div class="menu-item">
+        <div class="menu-item__title">
+          <i></i>
+          <span class="select" title="切换标题">正文</span>
+          <div class="options">
+            <ul>
+              <li style="font-size:16px;">正文</li>
+              <li data-level="first" style="font-size:26px;">标题1</li>
+              <li data-level="second" style="font-size:24px;">标题2</li>
+              <li data-level="third" style="font-size:22px;">标题3</li>
+              <li data-level="fourth" style="font-size:20px;">标题4</li>
+              <li data-level="fifth" style="font-size:18px;">标题5</li>
+              <li data-level="sixth" style="font-size:16px;">标题6</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__left">
+          <i></i>
+        </div>
+        <div class="menu-item__center">
+          <i></i>
+        </div>
+        <div class="menu-item__right">
+          <i></i>
+        </div>
+        <div class="menu-item__alignment">
+          <i></i>
+        </div>
+        <div class="menu-item__justify">
+          <i></i>
+        </div>
+        <div class="menu-item__row-margin">
+          <i title="行间距"></i>
+          <div class="options">
+            <ul>
+              <li data-rowmargin='1'>1</li>
+              <li data-rowmargin="1.25">1.25</li>
+              <li data-rowmargin="1.5">1.5</li>
+              <li data-rowmargin="1.75">1.75</li>
+              <li data-rowmargin="2">2</li>
+              <li data-rowmargin="2.5">2.5</li>
+              <li data-rowmargin="3">3</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__list">
+          <i></i>
+          <div class="options">
+            <ul>
+              <li>
+                <label>取消列表</label>
+              </li>
+              <li data-list-type="ol" data-list-style='decimal'>
+                <label>有序列表：</label>
+                <ol>
+                  <li>________</li>
+                </ol>
+              </li>
+              <li data-list-type="ul" data-list-style='checkbox'>
+                <label>复选框列表：</label>
+                <ul style="list-style-type: '☑️ ';">
+                  <li>________</li>
+                </ul>
+              </li>
+              <li data-list-type="ul" data-list-style='disc'>
+                <label>实心圆点列表：</label>
+                <ul style="list-style-type: disc;">
+                  <li>________</li>
+                </ul>
+              </li>
+              <li data-list-type="ul" data-list-style='circle'>
+                <label>空心圆点列表：</label>
+                <ul style="list-style-type: circle;">
+                  <li>________</li>
+                </ul>
+              </li>
+              <li data-list-type="ul" data-list-style='square'>
+                <label>空心方块列表：</label>
+                <ul style="list-style-type: '☐ ';">
+                  <li>________</li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="menu-divider"></div>
+      <div class="menu-item">
+        <div class="menu-item__table">
+          <i title="表格"></i>
+        </div>
+        <div class="menu-item__table__collapse">
+          <div class="table-close">×</div>
+          <div class="table-title">
+            <span class="table-select">插入</span>
+            <span>表格</span>
+          </div>
+          <div class="table-panel"></div>
+        </div>
+        <div class="menu-item__image">
+          <i title="图片"></i>
+          <input type="file" id="image" accept=".png, .jpg, .jpeg, .svg, .gif">
+        </div>
+        <div class="menu-item__hyperlink">
+          <i title="超链接"></i>
+        </div>
+        <div class="menu-item__separator">
+          <i title="分割线"></i>
+          <div class="options">
+            <ul>
+              <li data-separator='0,0'>
+                <i></i>
+              </li>
+              <li data-separator="1,1">
+                <i></i>
+              </li>
+              <li data-separator="3,1">
+                <i></i>
+              </li>
+              <li data-separator="4,4">
+                <i></i>
+              </li>
+              <li data-separator="7,3,3,3">
+                <i></i>
+              </li>
+              <li data-separator="6,2,2,2,2,2">
+                <i></i>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__watermark">
+          <i title="水印(添加、删除)"></i>
+          <div class="options">
+            <ul>
+              <li data-menu="add">添加水印</li>
+              <li data-menu="delete">删除水印</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__codeblock" title="代码块">
+          <i></i>
+        </div>
+        <div class="menu-item__page-break" title="分页符">
+          <i></i>
+        </div>
+        <div class="menu-item__control">
+          <i title="控件"></i>
+          <div class="options">
+            <ul>
+              <li data-control='text'>文本</li>
+              <li data-control="select">列举</li>
+              <li data-control="date">日期</li>
+              <li data-control="checkbox">复选框</li>
+              <li data-control="radio">单选框</li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__checkbox" title="复选框">
+          <i></i>
+        </div>
+        <div class="menu-item__radio" title="单选框">
+          <i></i>
+        </div>
+        <div class="menu-item__latex" title="LateX">
+          <i></i>
+        </div>
+        <div class="menu-item__date">
+          <i title="日期"></i>
+          <div class="options">
+            <ul>
+              <li data-format="yyyy-MM-dd"></li>
+              <li data-format="yyyy-MM-dd hh:mm:ss"></li>
+            </ul>
+          </div>
+        </div>
+        <div class="menu-item__block" title="内容块">
+          <i></i>
+        </div>
+      </div>
+      <div class="menu-divider"></div>
+      <div class="menu-item">
+        <div class="menu-item__search" data-menu="search">
+          <i></i>
+        </div>
+        <div class="menu-item__search__collapse" data-menu="search">
+          <div class="menu-item__search__collapse__search">
+            <input type="text" />
+            <label class="search-result"></label>
+            <div class="arrow-left">
+              <i></i>
+            </div>
+            <div class="arrow-right">
+              <i></i>
+            </div>
+            <span>×</span>
+          </div>
+          <div class="menu-item__search__collapse__replace">
+            <input type="text">
+            <button>替换</button>
+          </div>
+        </div>
+        <div class="menu-item__print" data-menu="print">
+          <i></i>
+        </div>
+      </div>
+    </div>
+    <div class="editor-and-pdf">
+      <div class="editor"></div>
+      <div class="pdf">
+        <iframe id="pdfDom" src=""  width="100%" height="100%" style="border: none;"></iframe>
+      </div>
+    </div>
+    <div class="footer" editor-component="footer">
+      <div>
+        <div class="page-mode">
+          <i title="页面模式(分页、连页)"></i>
+          <div class="options">
+            <ul>
+              <li data-page-mode="paging" class="active">分页</li>
+              <li data-page-mode="continuity">连页</li>
+            </ul>
+          </div>
+        </div>
+        <span>可见页码：<span class="page-no-list">1</span></span>
+        <span>页面：<span class="page-no">1</span>/<span class="page-size">1</span></span>
+        <span>字数：<span class="word-count">0</span></span>
+      </div>
+      <div class="editor-mode" title="编辑模式(编辑、清洁、只读、表单、设计)">编辑模式</div>
+      <div>
+        <div class="page-scale-minus" title="缩小(Ctrl+-)">
+          <i></i>
+        </div>
+        <span class="page-scale-percentage" title="显示比例(点击可复原Ctrl+0)">100%</span>
+        <div class="page-scale-add" title="放大(Ctrl+=)">
+          <i></i>
+        </div>
+        <div class="paper-size">
+          <i title="纸张类型"></i>
+          <div class="options">
+            <ul>
+              <li data-paper-size="794*1123" class="active">A4</li>
+              <li data-paper-size="1593*2251">A2</li>
+              <li data-paper-size="1125*1593">A3</li>
+              <li data-paper-size="565*796">A5</li>
+              <li data-paper-size="412*488">5号信封</li>
+              <li data-paper-size="450*866">6号信封</li>
+              <li data-paper-size="609*862">7号信封</li>
+              <li data-paper-size="862*1221">9号信封</li>
+              <li data-paper-size="813*1266">法律用纸</li>
+              <li data-paper-size="813*1054">信纸</li>
+            </ul>
+          </div>
+        </div>
+        <div class="paper-direction">
+          <i title="纸张方向"></i>
+          <div class="options">
+            <ul>
+              <li data-paper-direction="vertical" class="active">纵向</li>
+              <li data-paper-direction="horizontal">横向</li>
+            </ul>
+          </div>
+        </div>
+        <div class="paper-margin" title="页边距">
+          <i></i>
+        </div>
+        <div class="fullscreen" title="全屏显示">
+          <i></i>
+        </div>
+        <div class="editor-option" title="编辑器设置">
+          <i></i>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://unpkg.com/jspdf@latest/dist/jspdf.umd.min.js"></script>
+  <script type="module" src="/src/pdf-main.ts"></script>
+</body>
+
+</html>

--- a/src/editor/canvas/CanvasCERenderingContext.ts
+++ b/src/editor/canvas/CanvasCERenderingContext.ts
@@ -1,0 +1,268 @@
+import {
+  CERenderingContext,
+  DrawArea,
+  FontProperty,
+  LineDrawer,
+  LineProperty,
+  TextDirection
+} from '../interface/CERenderingContext'
+import { ITextMetrics } from '../interface/Text'
+import { Draw } from '../core/draw/Draw'
+
+export class CanvasCERenderingContext implements CERenderingContext {
+
+  constructor(private ctx: CanvasRenderingContext2D) {
+  }
+
+  get canvasCtx() {
+    return this.ctx
+  }
+
+  public drawImage(value: HTMLImageElement | string, dx: number, dy: number, width: number, height: number): void {
+    let img
+    if (typeof value === 'string') {
+      img = document.createElement('img')
+      img.src = value
+    } else {
+      img = value
+    }
+    this.ctx.drawImage(img, dx, dy, width, height)
+  }
+
+  public fillRect(x: number, y: number, width: number, height: number, prop: LineProperty): void {
+    this._execDraw(() => {
+      if (prop.translate) {
+        this.ctx.translate(...prop.translate)
+      }
+      if (prop.alpha !== undefined) {
+        this.ctx.globalAlpha = prop.alpha
+      }
+      if (prop.fillColor) {
+        this.ctx.fillStyle = prop.fillColor ?? '#000'
+      }
+      this.ctx.fillRect(x, y, width, height)
+    })
+  }
+
+  strokeRect(x: number, y: number, width: number, height: number, prop: LineProperty): void {
+    this._execDraw(() => {
+      if (prop.translate) {
+        this.ctx.translate(...prop.translate)
+      }
+      this.ctx.globalAlpha = prop.alpha ?? 1
+      if (prop.color) {
+        this.ctx.strokeStyle = prop.color ?? '#000'
+      }
+      this.ctx.strokeRect(x, y, width, height)
+    })
+  }
+
+  circle(x: number, y: number, r: number, prop: LineProperty): void {
+    this._execDraw(() => {
+      if (prop.translate) {
+        this.ctx.translate(...prop.translate)
+      }
+      this.ctx.globalAlpha = prop.alpha ?? 1
+      if (prop.color) {
+        this.ctx.strokeStyle = prop.color ?? '#000'
+      }
+      if (prop.fillColor) {
+        this.ctx.fillStyle = prop.fillColor ?? '#000'
+      }
+      this.ctx.arc(x, y, r, 0, 2 * Math.PI)
+      if (prop.color) {
+        this.ctx.stroke()
+      }
+      if (prop.fillColor) {
+        this.ctx.fill()
+      }
+    })
+  }
+
+  private _execDraw(action: () => void) {
+    this.ctx.save()
+    this.ctx.beginPath()
+    try {
+      action()
+    } finally {
+      this.ctx.closePath()
+      this.ctx.restore()
+    }
+  }
+
+  line(prop: LineProperty): LineDrawer {
+    return new CanvasRenderingContext2DLineDrawer(this, prop)
+  }
+
+  text(text: string, x: number, y: number, prop: FontProperty): void {
+    this.ctx.save()
+    let font = ''
+    if (prop.font) {
+      font = prop.font
+    }
+    if (prop.size) {
+      font = [`${prop.size}px`, font ?? ''].join(' ')
+    }
+    if (font) {
+      this.ctx.font = font
+    }
+    if (prop.color) {
+      this.ctx.fillStyle = prop.color
+    }
+    if (prop.alpha || prop.alpha === 0) {
+      this.ctx.globalAlpha = prop.alpha
+    }
+    if (prop.translate && prop.translate.length == 2) {
+      this.ctx.translate(...prop.translate)
+    }
+    if (prop.rotate) {
+      this.ctx.rotate(prop.rotate)
+    }
+    this.ctx.fillText(text, x, y)
+    this.ctx.restore()
+  }
+
+  translate(x: number, y: number): void {
+    this.ctx.translate(x, y)
+  }
+
+  scale(x: number, y: number): void {
+    this.ctx.scale(x, y)
+  }
+
+  initPageContext(scale: number, direction: TextDirection): void {
+    this.ctx.scale(scale, scale)
+    // 重置以下属性是因部分浏览器(chrome)会应用css样式
+    this.ctx.letterSpacing = '0px'
+    this.ctx.wordSpacing = '0px'
+    this.ctx.direction = direction
+  }
+
+  setGlobalAlpha(alpha: number): void {
+    this.ctx.globalAlpha = alpha
+  }
+
+  getGlobalAlpha(): number {
+    return this.ctx.globalAlpha
+  }
+
+  getFont(): string {
+    return this.ctx.font
+  }
+
+  measureText(text: string, prop: FontProperty): ITextMetrics {
+    let font
+    if (prop && prop.size && prop.font) {
+      font = `${prop.fontStyle ?? ''} ${prop.fontWeight ?? ''} ${prop.size ? `${prop.size}px` : ''} ${prop.font ?? ''}`
+    }
+
+    if (font && font.trim().length > 0) {
+      this.ctx.save()
+      this.ctx.font = font
+    }
+    const metrics = this.ctx.measureText(text)
+    if (font && font.trim().length > 0) {
+      this.ctx.restore()
+    }
+    return metrics
+  }
+
+  addWatermark(data: HTMLCanvasElement, area: DrawArea): void {
+    // 创建平铺模式
+    this.ctx.save()
+    if (area.alpha || area.alpha === 0) {
+      this.ctx.globalAlpha = area.alpha
+    }
+    const pattern = this.ctx.createPattern(data, 'repeat')
+    if (pattern) {
+      this.ctx.fillStyle = pattern
+      this.ctx.fillRect(area.startX, area.startY, area.width, area.height)
+    }
+    this.ctx.restore()
+
+  }
+
+  addWatermarkSingle(data: string, draw: Draw, prop: FontProperty, metrics: ITextMetrics): void {
+    const width = draw.getWidth()
+    const height = draw.getHeight()
+    const {watermark: {size}} = draw.getOptions()
+    prop.translate = [width/2, height/2]
+    prop.rotate = -45 * Math.PI/180
+    this.text(data,  -metrics.width / 2,
+      metrics.actualBoundingBoxAscent - size / 2, prop)
+  }
+
+
+
+  cleanPage(pageWidth: number, pageHeight: number): void {
+    this.ctx.clearRect(0, 0, pageWidth, pageHeight)
+  }
+}
+
+export class CanvasRenderingContext2DLineDrawer implements LineDrawer {
+  private actions: (() => void)[] = []
+  private _beforeDraw: ((ctx: CERenderingContext) => void) | null = null
+  private readonly alpha: number
+  private readonly lineWidth: number
+  private readonly strikeoutColor: string
+  private readonly ctx: CanvasRenderingContext2D
+
+  constructor(private _ctx: CanvasCERenderingContext, private prop: LineProperty) {
+    this.alpha = this.prop.alpha ?? 1
+    this.lineWidth = this.prop.lineWidth ?? 1
+    this.strikeoutColor = this.prop.color ?? '#000'
+    this.ctx = _ctx.canvasCtx
+  }
+
+  beforeDraw(action: (ctx: CERenderingContext) => void): LineDrawer {
+    this._beforeDraw = action
+    return this
+  }
+
+
+  path(x1: number, y1: number, x2?: number, y2?: number): LineDrawer {
+    this.actions.push(() => {
+
+      if (typeof x2 !== 'number' || typeof y2 !== 'number') {
+        this.ctx.lineTo(x1, y1)
+      } else {
+        this.ctx.moveTo(x1, y1)
+        this.ctx.lineTo(x2, y2)
+      }
+    })
+    return this
+  }
+
+
+  public draw() {
+    if (!this.actions.length) {
+      return
+    }
+    this.ctx.save()
+    this.ctx.globalAlpha = this.alpha
+    this.ctx.lineWidth = this.lineWidth
+    this.ctx.strokeStyle = this.strikeoutColor
+    this.ctx.beginPath()
+    if (this.prop.lineCap) {
+      this.ctx.lineCap = this.prop.lineCap
+    }
+    if (this.prop.lineJoin) {
+      this.ctx.lineJoin = this.prop.lineJoin
+    }
+    if (this.prop.lineDash) {
+      this.ctx.setLineDash(this.prop.lineDash)
+    }
+    try {
+      if (typeof this._beforeDraw === 'function') {
+        this._beforeDraw(this._ctx)
+      }
+      for (let i = 0; i < this.actions.length; i++) {
+        this.actions[i]()
+      }
+    } finally {
+      this.ctx.stroke()
+      this.ctx.closePath()
+      this.ctx.restore()
+    }
+  }
+}

--- a/src/editor/core/command/Command.ts
+++ b/src/editor/core/command/Command.ts
@@ -104,6 +104,7 @@ export class Command {
   public executeFocus: CommandAdapt['focus']
   public getCatalog: CommandAdapt['getCatalog']
   public getImage: CommandAdapt['getImage']
+  public getPdf: CommandAdapt['getPdf']
   public getOptions: CommandAdapt['getOptions']
   public getValue: CommandAdapt['getValue']
   public getAreaValue: CommandAdapt['getAreaValue']
@@ -237,6 +238,7 @@ export class Command {
     this.executeFocus = adapt.focus.bind(adapt)
     // 获取
     this.getImage = adapt.getImage.bind(adapt)
+    this.getPdf = adapt.getPdf.bind(adapt)
     this.getOptions = adapt.getOptions.bind(adapt)
     this.getValue = adapt.getValue.bind(adapt)
     this.getHTML = adapt.getHTML.bind(adapt)

--- a/src/editor/core/command/CommandAdapt.ts
+++ b/src/editor/core/command/CommandAdapt.ts
@@ -45,7 +45,7 @@ import {
   IDrawImagePayload,
   IDrawOption,
   IForceUpdateOption,
-  IGetImageOption,
+  IGetImageOption, IGetPdfOption,
   IGetValueOption,
   IPainterOption
 } from '../../interface/Draw'
@@ -120,6 +120,7 @@ import {
   ISetAreaPropertiesOption
 } from '../../interface/Area'
 import { IAreaBadge, IBadge } from '../../interface/Badge'
+import { DrawPdf } from '../draw/DrawPdf'
 
 export class CommandAdapt {
   private draw: Draw
@@ -1451,6 +1452,10 @@ export class CommandAdapt {
 
   public getImage(payload?: IGetImageOption): Promise<string[]> {
     return this.draw.getDataURL(payload)
+  }
+
+  public getPdf(option: IGetPdfOption): Promise<Blob> {
+    return new DrawPdf(this.draw, option).genPdf()
   }
 
   public getOptions(): DeepRequired<IEditorOption> {

--- a/src/editor/core/draw/DrawPdf.ts
+++ b/src/editor/core/draw/DrawPdf.ts
@@ -1,0 +1,138 @@
+import { Draw } from './Draw'
+import { IDrawPagePayload, IGetPdfOption } from '../../interface/Draw'
+import { PdfCERenderingContext } from '../../pdf/PdfCERenderingContext'
+import { EditorMode, EditorZone, PageMode } from '../../dataset/enum/Editor'
+import { ImageDisplay } from '../../dataset/enum/Common'
+import { ImageParticle } from './particle/ImageParticle'
+import jsPDF from 'jspdf'
+
+export class DrawPdf {
+  private ctxList: PdfCERenderingContext[]
+  private draw: Draw
+  private doc: jsPDF
+
+  constructor(draw: Draw, private option: IGetPdfOption = {}) {
+    this.ctxList = []
+    this.draw = draw
+    const options = this.draw.getOptions()
+    const { width, height } = options
+    this.doc = new window.jspdf.jsPDF({
+      orientation: 'p',
+      unit: 'px',
+      format: [width, height],
+      hotfixes: ['px_scaling'],
+      compress: true
+    })
+    const pageList = this.draw.getPageList()
+    if (pageList && pageList.length) {
+      for (let i = 0; i < pageList.length; i++) {
+        if (i !=0) {
+          this.doc.addPage([width, height])
+        }
+        this.ctxList.push(new PdfCERenderingContext(i+1, this.doc))
+      }
+      this.doc.setPage(1)
+    }
+  }
+
+  public genPdf(): Promise<Blob> {
+
+    if (typeof this.option.beforeExport === 'function') {
+      this.option.beforeExport(this.doc)
+    }
+    const mode = this.draw.getMode()
+    if (mode != EditorMode.PRINT) {
+      this.draw.setMode(EditorMode.PRINT)
+    }
+    const positionList = this.draw.getPosition().getOriginalMainPositionList()
+    const elementList = this.draw.getOriginalMainElementList()
+    const pageRowList = this.draw.getPageRowList()
+    try {
+      for (let i = 0; i < pageRowList.length; i++) {
+        this._drawPage({
+          elementList,
+          positionList,
+          rowList: pageRowList[i],
+          pageNo: i
+        })
+      }
+      if (mode != EditorMode.PRINT) {
+        this.draw.setMode(mode)
+      }
+    } catch (e) {
+      console.error(e)
+      if (mode != EditorMode.PRINT) {
+        this.draw.setMode(mode)
+      }
+    }
+    const promises: Promise<any>[] = []
+    for (let i = 0; i < this.ctxList.length; i++) {
+      promises.push(this.ctxList[i].loadOver())
+    }
+    return Promise.all(promises).then(() => {
+      return this.doc.output('blob')
+    })
+  }
+
+  private _drawPage(payload: IDrawPagePayload) {
+    const { elementList, positionList, rowList, pageNo } = payload
+    const {
+      pageMode,
+      header,
+      footer,
+      pageNumber,
+      pageBorder
+    } = this.draw.getOptions()
+    const innerWidth = this.draw.getInnerWidth()
+    const ctx = this.ctxList[pageNo]
+    // 判断当前激活区域-非正文区域时元素透明度降低
+    // 绘制背景
+    this.draw.getBackground().render(ctx, pageNo)
+    // 渲染衬于文字下方元素
+    ImageParticle.drawFloat(ctx, {
+      pageNo,
+      imgDisplays: [ImageDisplay.FLOAT_BOTTOM]
+    }, 1, this.draw.getPosition().getFloatPositionList(), this.draw.getImageParticle())
+    // 渲染元素
+    const index = rowList[0]?.startIndex
+
+    this.draw.drawRow(ctx, {
+      elementList,
+      positionList,
+      rowList,
+      pageNo,
+      startIndex: index,
+      innerWidth,
+      zone: EditorZone.MAIN
+    })
+    if (this.draw.getIsPagingMode()) {
+      // 绘制页眉
+      if (!header.disabled) {
+        this.draw.getHeader().render(ctx, pageNo)
+      }
+      // 绘制页码
+      if (!pageNumber.disabled) {
+        this.draw.getPageNumber().render(ctx, pageNo)
+      }
+      // 绘制页脚
+      if (!footer.disabled) {
+        this.draw.getFooter().render(ctx, pageNo)
+      }
+    }
+    // 渲染浮于文字上方元素
+    ImageParticle.drawFloat(ctx, {
+      pageNo,
+      imgDisplays: [ImageDisplay.FLOAT_TOP, ImageDisplay.SURROUND]
+    }, 1, this.draw.getPosition().getFloatPositionList(), this.draw.getImageParticle())
+
+    // 绘制水印
+    if (pageMode !== PageMode.CONTINUITY && this.draw.getOptions().watermark.data) {
+      this.draw.getWaterMark().render(ctx)
+    }
+
+    // 绘制页面边框
+    if (!pageBorder.disabled) {
+      this.draw.getPageBorder().render(ctx)
+    }
+  }
+}

--- a/src/editor/core/draw/control/Control.ts
+++ b/src/editor/core/draw/control/Control.ts
@@ -59,6 +59,7 @@ import {
 import { IRowElement } from '../../../interface/Row'
 import { RowFlex } from '../../../dataset/enum/Row'
 import { ZERO } from '../../../dataset/constant/Common'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 interface IMoveCursorResult {
   newIndex: number
@@ -103,7 +104,7 @@ export class Control {
     }
   }
 
-  public renderHighlightList(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public renderHighlightList(ctx: CERenderingContext, pageNo: number) {
     const highlightMatchResult = this.controlSearch.getHighlightMatchResult()
     if (highlightMatchResult.length) {
       this.controlSearch.renderHighlightList(ctx, pageNo)
@@ -1158,7 +1159,7 @@ export class Control {
     this.controlBorder.recordBorderInfo(x, y, width, height)
   }
 
-  public drawBorder(ctx: CanvasRenderingContext2D) {
+  public drawBorder(ctx: CERenderingContext) {
     this.controlBorder.render(ctx)
   }
 

--- a/src/editor/core/draw/control/interactive/ControlSearch.ts
+++ b/src/editor/core/draw/control/interactive/ControlSearch.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../interface/Search'
 import { Draw } from '../../Draw'
 import { Control } from '../Control'
+import { CERenderingContext } from '../../../../interface/CERenderingContext'
 
 type IHighlightMatchResult = (ISearchResult & IControlHighlightRule)[]
 
@@ -120,12 +121,11 @@ export class ControlSearch {
     computeHighlight(this.draw.getOriginalMainElementList())
   }
 
-  public renderHighlightList(ctx: CanvasRenderingContext2D, pageIndex: number) {
+  public renderHighlightList(ctx: CERenderingContext, pageIndex: number) {
     if (!this.highlightMatchResult?.length) return
     const { searchMatchAlpha, searchMatchColor } = this.options
     const positionList = this.draw.getPosition().getOriginalPositionList()
     const elementList = this.draw.getOriginalElementList()
-    ctx.save()
     for (let s = 0; s < this.highlightMatchResult.length; s++) {
       const searchMatch = this.highlightMatchResult[s]
       let position: IElementPosition | null = null
@@ -143,14 +143,14 @@ export class ControlSearch {
         pageNo
       } = position
       if (pageNo !== pageIndex) continue
-      ctx.fillStyle = searchMatch.backgroundColor || searchMatchColor
-      ctx.globalAlpha = searchMatch.alpha || searchMatchAlpha
       const x = leftTop[0]
       const y = leftTop[1]
       const width = rightTop[0] - leftTop[0]
       const height = leftBottom[1] - leftTop[1]
-      ctx.fillRect(x, y, width, height)
+      ctx.fillRect(x, y, width, height, {
+        fillColor: searchMatch.backgroundColor || searchMatchColor,
+        alpha: searchMatch.alpha || searchMatchAlpha
+      })
     }
-    ctx.restore()
   }
 }

--- a/src/editor/core/draw/control/richtext/Border.ts
+++ b/src/editor/core/draw/control/richtext/Border.ts
@@ -2,6 +2,7 @@ import { DeepRequired } from '../../../../interface/Common'
 import { IEditorOption } from '../../../../interface/Editor'
 import { IElementFillRect } from '../../../../interface/Element'
 import { Draw } from '../../Draw'
+import { CERenderingContext } from '../../../../interface/CERenderingContext'
 
 export class ControlBorder {
   protected borderRect: IElementFillRect
@@ -32,21 +33,16 @@ export class ControlBorder {
     this.borderRect.width += width
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     if (!this.borderRect.width) return
     const {
       scale,
       control: { borderWidth, borderColor }
     } = this.options
     const { x, y, width, height } = this.borderRect
-    ctx.save()
-    ctx.translate(0, 1 * scale)
-    ctx.lineWidth = borderWidth * scale
-    ctx.strokeStyle = borderColor
-    ctx.beginPath()
-    ctx.rect(x, y, width, height)
-    ctx.stroke()
-    ctx.restore()
+    ctx.strokeRect(x, y, width, height, {
+      lineWidth: borderWidth * scale, color: borderColor, translate: [0, 1 * scale]
+    })
     this.clearBorderInfo()
   }
 }

--- a/src/editor/core/draw/frame/Background.ts
+++ b/src/editor/core/draw/frame/Background.ts
@@ -5,6 +5,7 @@ import {
 import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Background {
   private draw: Draw
@@ -18,19 +19,18 @@ export class Background {
   }
 
   private _renderBackgroundColor(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     color: string,
     width: number,
     height: number
   ) {
-    ctx.save()
-    ctx.fillStyle = color
-    ctx.fillRect(0, 0, width, height)
-    ctx.restore()
+    ctx.fillRect(0, 0, width, height, {
+      fillColor: color
+    })
   }
 
   private _drawImage(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     imageElement: HTMLImageElement,
     width: number,
     height: number
@@ -74,7 +74,7 @@ export class Background {
   }
 
   private _renderBackgroundImage(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     width: number,
     height: number
   ) {
@@ -98,7 +98,7 @@ export class Background {
     }
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     const {
       background: { image, color, applyPageNumbers }
     } = this.options

--- a/src/editor/core/draw/frame/Badge.ts
+++ b/src/editor/core/draw/frame/Badge.ts
@@ -2,6 +2,7 @@ import { IAreaBadge, IBadge } from '../../../interface/Badge'
 import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Badge {
   private draw: Draw
@@ -30,7 +31,7 @@ export class Badge {
   }
 
   private _drawImage(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     x: number,
     y: number,
     width: number,
@@ -51,7 +52,7 @@ export class Badge {
     }
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     // 文档签章
     if (pageNo === 0 && this.mainBadge) {
       const { scale, badge } = this.options

--- a/src/editor/core/draw/frame/Footer.ts
+++ b/src/editor/core/draw/frame/Footer.ts
@@ -6,6 +6,7 @@ import { IElement, IElementPosition } from '../../../interface/Element'
 import { IRow } from '../../../interface/Row'
 import { Position } from '../../position/Position'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Footer {
   private draw: Draw
@@ -119,8 +120,8 @@ export class Footer {
     return extraHeight <= 0 ? 0 : extraHeight
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
-    ctx.globalAlpha = 1
+  public render(ctx: CERenderingContext, pageNo: number) {
+    ctx.setGlobalAlpha(1)
     const innerWidth = this.draw.getInnerWidth()
     const maxHeight = this.getMaxHeight()
     // 超出最大高度不渲染

--- a/src/editor/core/draw/frame/Header.ts
+++ b/src/editor/core/draw/frame/Header.ts
@@ -7,6 +7,7 @@ import { IRow } from '../../../interface/Row'
 import { pickSurroundElementList } from '../../../utils/element'
 import { Position } from '../../position/Position'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Header {
   private draw: Draw
@@ -122,8 +123,8 @@ export class Header {
     return extraHeight <= 0 ? 0 : extraHeight
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
-    ctx.globalAlpha = 1
+  public render(ctx: CERenderingContext, pageNo: number) {
+    ctx.setGlobalAlpha(1)
     const innerWidth = this.draw.getInnerWidth()
     const maxHeight = this.getMaxHeight()
     // 超出最大高度不渲染

--- a/src/editor/core/draw/frame/LineNumber.ts
+++ b/src/editor/core/draw/frame/LineNumber.ts
@@ -2,6 +2,7 @@ import { LineNumberType } from '../../../dataset/enum/LineNumber'
 import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class LineNumber {
   private draw: Draw
@@ -12,7 +13,7 @@ export class LineNumber {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     const {
       scale,
       lineNumber: { color, size, font, right, type }
@@ -22,9 +23,6 @@ export class LineNumber {
     const positionList = this.draw.getPosition().getOriginalMainPositionList()
     const pageRowList = this.draw.getPageRowList()
     const rowList = pageRowList[pageNo]
-    ctx.save()
-    ctx.fillStyle = color
-    ctx.font = `${size * scale}px ${font}`
     for (let i = 0; i < rowList.length; i++) {
       const row = rowList[i]
       const {
@@ -36,8 +34,9 @@ export class LineNumber {
       })
       const x = margins[3] - (textMetrics.width + right) * scale
       const y = leftBottom[1] - textMetrics.actualBoundingBoxAscent * scale
-      ctx.fillText(`${seq}`, x, y)
+      ctx.text(`${seq}`, x, y, {
+        color, size: size * scale, font
+      })
     }
-    ctx.restore()
   }
 }

--- a/src/editor/core/draw/frame/Margin.ts
+++ b/src/editor/core/draw/frame/Margin.ts
@@ -1,6 +1,7 @@
 import { PageMode } from '../../../dataset/enum/Editor'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Margin {
   private draw: Draw
@@ -11,7 +12,7 @@ export class Margin {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     const { marginIndicatorColor, pageMode } = this.options
     const width = this.draw.getWidth()
     const height =
@@ -20,10 +21,6 @@ export class Margin {
         : this.draw.getHeight()
     const margins = this.draw.getMargins()
     const marginIndicatorSize = this.draw.getMarginIndicatorSize()
-    ctx.save()
-    ctx.translate(0.5, 0.5)
-    ctx.strokeStyle = marginIndicatorColor
-    ctx.beginPath()
     const leftTopPoint: [number, number] = [margins[3], margins[0]]
     const rightTopPoint: [number, number] = [width - margins[1], margins[0]]
     const leftBottomPoint: [number, number] = [margins[3], height - margins[2]]
@@ -31,23 +28,21 @@ export class Margin {
       width - margins[1],
       height - margins[2]
     ]
+    ctx.line({
+      color: marginIndicatorColor
+    }).beforeDraw(c => c.translate(.5,.5))
     // 上左
-    ctx.moveTo(leftTopPoint[0] - marginIndicatorSize, leftTopPoint[1])
-    ctx.lineTo(...leftTopPoint)
-    ctx.lineTo(leftTopPoint[0], leftTopPoint[1] - marginIndicatorSize)
+      .path(leftTopPoint[0] - marginIndicatorSize, leftTopPoint[1], ...leftTopPoint)
+      .path(leftTopPoint[0], leftTopPoint[1] - marginIndicatorSize)
     // 上右
-    ctx.moveTo(rightTopPoint[0] + marginIndicatorSize, rightTopPoint[1])
-    ctx.lineTo(...rightTopPoint)
-    ctx.lineTo(rightTopPoint[0], rightTopPoint[1] - marginIndicatorSize)
+      .path(rightTopPoint[0] + marginIndicatorSize, rightTopPoint[1], ...rightTopPoint)
+      .path(rightTopPoint[0], rightTopPoint[1] - marginIndicatorSize)
     // 下左
-    ctx.moveTo(leftBottomPoint[0] - marginIndicatorSize, leftBottomPoint[1])
-    ctx.lineTo(...leftBottomPoint)
-    ctx.lineTo(leftBottomPoint[0], leftBottomPoint[1] + marginIndicatorSize)
+      .path(leftBottomPoint[0] - marginIndicatorSize, leftBottomPoint[1], ...leftBottomPoint)
+      .path(leftBottomPoint[0], leftBottomPoint[1] + marginIndicatorSize)
     // 下右
-    ctx.moveTo(rightBottomPoint[0] + marginIndicatorSize, rightBottomPoint[1])
-    ctx.lineTo(...rightBottomPoint)
-    ctx.lineTo(rightBottomPoint[0], rightBottomPoint[1] + marginIndicatorSize)
-    ctx.stroke()
-    ctx.restore()
+      .path(rightBottomPoint[0] + marginIndicatorSize, rightBottomPoint[1], ...rightBottomPoint)
+      .path(rightBottomPoint[0], rightBottomPoint[1] + marginIndicatorSize)
+      .draw()
   }
 }

--- a/src/editor/core/draw/frame/PageBorder.ts
+++ b/src/editor/core/draw/frame/PageBorder.ts
@@ -3,6 +3,7 @@ import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
 import { Footer } from './Footer'
 import { Header } from './Header'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class PageBorder {
   private draw: Draw
@@ -17,15 +18,11 @@ export class PageBorder {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     const {
       scale,
       pageBorder: { color, lineWidth, padding }
     } = this.options
-    ctx.save()
-    ctx.translate(0.5, 0.5)
-    ctx.strokeStyle = color
-    ctx.lineWidth = lineWidth * scale
     const margins = this.draw.getMargins()
     // x：左边距 - 左距离正文距离
     const x = margins[3] - padding[3] * scale
@@ -40,8 +37,9 @@ export class PageBorder {
       this.footer.getExtraHeight() -
       margins[2] +
       padding[2] * scale
-    ctx.rect(x, y, width, height)
-    ctx.stroke()
-    ctx.restore()
+
+    ctx.strokeRect(x, y, width, height, {
+      color, lineWidth: lineWidth * scale, translate: [0.5, 0.5]
+    })
   }
 }

--- a/src/editor/core/draw/frame/PageNumber.ts
+++ b/src/editor/core/draw/frame/PageNumber.ts
@@ -5,6 +5,7 @@ import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { convertNumberToChinese } from '../../../utils'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class PageNumber {
   private draw: Draw
@@ -15,7 +16,7 @@ export class PageNumber {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     const {
       scale,
       pageNumber: {
@@ -55,9 +56,6 @@ export class PageNumber {
     const height = this.draw.getHeight()
     const pageNumberBottom = this.draw.getPageNumberBottom()
     const y = height - pageNumberBottom
-    ctx.save()
-    ctx.fillStyle = color
-    ctx.font = `${size * scale}px ${font}`
     // 计算x位置-居左、居中、居右
     let x = 0
     const margins = this.draw.getMargins()
@@ -69,7 +67,8 @@ export class PageNumber {
     } else {
       x = margins[3]
     }
-    ctx.fillText(text, x, y)
-    ctx.restore()
+    ctx.text(text, x, y, {
+      font: `${size * scale}px ${font}`, color
+    })
   }
 }

--- a/src/editor/core/draw/frame/Placeholder.ts
+++ b/src/editor/core/draw/frame/Placeholder.ts
@@ -6,6 +6,7 @@ import { formatElementList } from '../../../utils/element'
 import { Position } from '../../position/Position'
 import { Draw } from '../Draw'
 import { LineBreakParticle } from '../particle/LineBreakParticle'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Placeholder {
   private draw: Draw
@@ -68,7 +69,7 @@ export class Placeholder {
     })
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     const {
       placeholder: { data, font, size, color, opacity }
     } = this.options
@@ -91,8 +92,8 @@ export class Placeholder {
     this._compute()
     const innerWidth = this.draw.getInnerWidth()
     // 绘制
-    ctx.save()
-    ctx.globalAlpha = opacity
+    const oriOpacity = ctx.getGlobalAlpha()
+    ctx.setGlobalAlpha(opacity)
     this.draw.drawRow(ctx, {
       elementList: this.elementList,
       positionList: this.positionList,
@@ -102,6 +103,7 @@ export class Placeholder {
       innerWidth,
       isDrawLineBreak: false
     })
-    ctx.restore()
+    // 方法内部的调用无法被还原
+    ctx.setGlobalAlpha(oriOpacity)
   }
 }

--- a/src/editor/core/draw/interactive/Area.ts
+++ b/src/editor/core/draw/interactive/Area.ts
@@ -15,6 +15,7 @@ import { Zone } from '../../zone/Zone'
 import { Position } from '../../position/Position'
 import { zipElementList } from '../../../utils/element'
 import { AreaMode } from '../../../dataset/enum/Area'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Area {
   private draw: Draw
@@ -94,9 +95,8 @@ export class Area {
     return areaId
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageNo: number) {
+  public render(ctx: CERenderingContext, pageNo: number) {
     if (!this.areaInfoMap.size) return
-    ctx.save()
     const margins = this.draw.getMargins()
     const width = this.draw.getInnerWidth()
     for (const areaInfoItem of this.areaInfoMap) {
@@ -104,7 +104,6 @@ export class Area {
       if (!area?.backgroundColor && !area?.borderColor) continue
       const pagePositionList = positionList.filter(p => p.pageNo === pageNo)
       if (!pagePositionList.length) continue
-      ctx.translate(0.5, 0.5)
       const firstPosition = pagePositionList[0]
       const lastPosition = pagePositionList[pagePositionList.length - 1]
       // 起始位置
@@ -113,16 +112,19 @@ export class Area {
       const height = Math.ceil(lastPosition.coordinate.rightBottom[1] - y)
       // 背景色
       if (area.backgroundColor) {
-        ctx.fillStyle = area.backgroundColor
-        ctx.fillRect(x, y, width, height)
+        ctx.fillRect(x, y, width, height, {
+          translate: [0.5, 0.5],
+          fillColor: area.backgroundColor
+        })
       }
       // 边框
       if (area.borderColor) {
-        ctx.strokeStyle = area.borderColor
-        ctx.strokeRect(x, y, width, height)
+        ctx.strokeRect(x, y, width, height, {
+          translate: [0.5, 0.5],
+          color: area.borderColor
+        })
       }
     }
-    ctx.restore()
   }
 
   public compute() {

--- a/src/editor/core/draw/interactive/Group.ts
+++ b/src/editor/core/draw/interactive/Group.ts
@@ -8,6 +8,7 @@ import { IRange } from '../../../interface/Range'
 import { getUUID } from '../../../utils'
 import { RangeManager } from '../../range/RangeManager'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Group {
   private draw: Draw
@@ -171,7 +172,7 @@ export class Group {
     }
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     if (!this.fillRectMap.size) return
     // 当前激活组信息
     const range = this.range.getRange()
@@ -180,19 +181,20 @@ export class Group {
     const {
       group: { backgroundColor, opacity, activeOpacity, activeBackgroundColor }
     } = this.options
-    ctx.save()
     this.fillRectMap.forEach((fillRect, groupId) => {
       const { x, y, width, height } = fillRect
+      let alpha, fillStyle
       if (anchorGroupIds?.includes(groupId)) {
-        ctx.globalAlpha = activeOpacity
-        ctx.fillStyle = activeBackgroundColor
+        alpha = activeOpacity
+        fillStyle = activeBackgroundColor
       } else {
-        ctx.globalAlpha = opacity
-        ctx.fillStyle = backgroundColor
+        alpha = opacity
+        fillStyle = backgroundColor
       }
-      ctx.fillRect(x, y, width, height)
+      ctx.fillRect(x, y, width, height, {
+        alpha, fillColor: fillStyle
+      })
     })
-    ctx.restore()
     this.clearFillInfo()
   }
 }

--- a/src/editor/core/draw/interactive/Search.ts
+++ b/src/editor/core/draw/interactive/Search.ts
@@ -9,6 +9,7 @@ import { ISearchResult, ISearchResultRestArgs } from '../../../interface/Search'
 import { getUUID } from '../../../utils'
 import { Position } from '../../position/Position'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export interface INavigateInfo {
   index: number
@@ -272,7 +273,7 @@ export class Search {
     )
   }
 
-  public render(ctx: CanvasRenderingContext2D, pageIndex: number) {
+  public render(ctx: CERenderingContext, pageIndex: number) {
     if (
       !this.searchMatchList ||
       !this.searchMatchList.length ||
@@ -284,8 +285,6 @@ export class Search {
       this.options
     const positionList = this.position.getOriginalPositionList()
     const elementList = this.draw.getOriginalElementList()
-    ctx.save()
-    ctx.globalAlpha = searchMatchAlpha
     for (let s = 0; s < this.searchMatchList.length; s++) {
       const searchMatch = this.searchMatchList[s]
       let position: IElementPosition | null = null
@@ -305,22 +304,24 @@ export class Search {
       if (pageNo !== pageIndex) continue
       // 高亮并定位当前搜索词
       const searchMatchIndexList = this.getSearchNavigateIndexList()
+      let color
       if (searchMatchIndexList.includes(s)) {
-        ctx.fillStyle = searchNavigateMatchColor
+        color = searchNavigateMatchColor
         // 是否是第一个字符，则移动到可视范围
         const preSearchMatch = this.searchMatchList[s - 1]
         if (!preSearchMatch || preSearchMatch.groupId !== searchMatch.groupId) {
           this.searchNavigateScrollIntoView(position)
         }
       } else {
-        ctx.fillStyle = searchMatchColor
+        color = searchMatchColor
       }
       const x = leftTop[0]
       const y = leftTop[1]
       const width = rightTop[0] - leftTop[0]
       const height = leftBottom[1] - leftTop[1]
-      ctx.fillRect(x, y, width, height)
+      ctx.fillRect(x, y, width, height, {
+        fillColor: color, alpha: searchMatchAlpha
+      })
     }
-    ctx.restore()
   }
 }

--- a/src/editor/core/draw/particle/CheckboxParticle.ts
+++ b/src/editor/core/draw/particle/CheckboxParticle.ts
@@ -5,9 +5,10 @@ import { IEditorOption } from '../../../interface/Editor'
 import { IElement } from '../../../interface/Element'
 import { IRow, IRowElement } from '../../../interface/Row'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 interface ICheckboxRenderOption {
-  ctx: CanvasRenderingContext2D
+  ctx: CERenderingContext
   x: number
   y: number
   row: IRow
@@ -78,34 +79,27 @@ export class CheckboxParticle {
     const top = Math.round(y - metrics.height + lineWidth)
     const width = metrics.width - gap * 2 * scale
     const height = metrics.height
-    ctx.save()
-    ctx.beginPath()
-    ctx.translate(0.5, 0.5)
     // 绘制勾选状态
     if (checkbox?.value) {
       // 边框
-      ctx.lineWidth = lineWidth
-      ctx.strokeStyle = fillStyle
-      ctx.rect(left, top, width, height)
-      ctx.stroke()
+      ctx.strokeRect(left, top, width, height, {
+        translate: [0.5, 0.5], lineWidth, color: fillStyle
+      })
       // 背景色
-      ctx.beginPath()
-      ctx.fillStyle = fillStyle
-      ctx.fillRect(left, top, width, height)
+      ctx.fillRect(left, top, width, height, {
+        translate: [0.5, 0.5], fillColor: fillStyle, lineWidth
+      })
       // 勾选对号
-      ctx.beginPath()
-      ctx.strokeStyle = strokeStyle
-      ctx.lineWidth = lineWidth * 2 * scale
-      ctx.moveTo(left + 2 * scale, top + height / 2)
-      ctx.lineTo(left + width / 2, top + height - 3 * scale)
-      ctx.lineTo(left + width - 2 * scale, top + 3 * scale)
-      ctx.stroke()
+      ctx.line({
+        color: strokeStyle, lineWidth: lineWidth * 2 * scale, translate: [0.5,0.5]
+      })
+        .path(left + 2 * scale, top + height / 2, left + width / 2, top + height - 3 * scale)
+        .path(left + width - 2 * scale, top + 3 * scale)
+        .draw()
     } else {
-      ctx.lineWidth = lineWidth
-      ctx.rect(left, top, width, height)
-      ctx.stroke()
+      ctx.strokeRect(left, top, width, height, {
+        lineWidth, translate: [0.5, 0.5]
+      })
     }
-    ctx.closePath()
-    ctx.restore()
   }
 }

--- a/src/editor/core/draw/particle/HyperlinkParticle.ts
+++ b/src/editor/core/draw/particle/HyperlinkParticle.ts
@@ -4,6 +4,7 @@ import { IEditorOption } from '../../../interface/Editor'
 import { IElementPosition } from '../../../interface/Element'
 import { IRowElement } from '../../../interface/Row'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class HyperlinkParticle {
   private draw: Draw
@@ -66,21 +67,20 @@ export class HyperlinkParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
   ) {
-    ctx.save()
-    ctx.font = element.style
     if (!element.color) {
       element.color = this.options.defaultHyperlinkColor
     }
-    ctx.fillStyle = element.color
     if (element.underline === undefined) {
       element.underline = true
     }
-    ctx.fillText(element.value, x, y)
-    ctx.restore()
+
+    ctx.text(element.value, x, y, {
+      font: element.style, color: element.color
+    })
   }
 }

--- a/src/editor/core/draw/particle/ImageParticle.ts
+++ b/src/editor/core/draw/particle/ImageParticle.ts
@@ -4,6 +4,11 @@ import { IEditorOption } from '../../../interface/Editor'
 import { IElement } from '../../../interface/Element'
 import { convertStringToBase64 } from '../../../utils'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
+import { IDrawFloatPayload } from '../../../interface/Draw'
+import { IFloatPosition } from '../../../interface/Position'
+import { EditorZone } from '../../../dataset/enum/Editor'
+import { ElementType } from '../../../dataset/enum/Element'
 
 export class ImageParticle {
   private draw: Draw
@@ -94,7 +99,7 @@ export class ImageParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IElement,
     x: number,
     y: number
@@ -134,6 +139,30 @@ export class ImageParticle {
         }
       })
       this.addImageObserver(imageLoadPromise)
+    }
+  }
+
+  public static drawFloat(ctx: CERenderingContext, payload: IDrawFloatPayload, scale: number, positionList: IFloatPosition[], imgParticle: ImageParticle) {
+    const { imgDisplays, pageNo } = payload
+    for (let e = 0; e < positionList.length; e++) {
+      const floatPosition = positionList[e]
+      const element = floatPosition.element
+      if (
+        (pageNo === floatPosition.pageNo ||
+          floatPosition.zone === EditorZone.HEADER ||
+          floatPosition.zone == EditorZone.FOOTER) &&
+        element.imgDisplay &&
+        imgDisplays.includes(element.imgDisplay) &&
+        element.type === ElementType.IMAGE
+      ) {
+        const imgFloatPosition = element.imgFloatPosition!
+        imgParticle.render(
+          ctx,
+          element,
+          imgFloatPosition.x * scale,
+          imgFloatPosition.y * scale
+        )
+      }
     }
   }
 }

--- a/src/editor/core/draw/particle/LineBreakParticle.ts
+++ b/src/editor/core/draw/particle/LineBreakParticle.ts
@@ -2,6 +2,7 @@ import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { IRowElement } from '../../../interface/Row'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class LineBreakParticle {
   private options: DeepRequired<IEditorOption>
@@ -14,7 +15,7 @@ export class LineBreakParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
@@ -23,33 +24,25 @@ export class LineBreakParticle {
       scale,
       lineBreak: { color, lineWidth }
     } = this.options
-    ctx.save()
-    ctx.beginPath()
     // 换行符尺寸设置为9像素
     const top = y - (LineBreakParticle.HEIGHT * scale) / 2
     const left = x + element.metrics.width
     // 移动位置并设置缩放
-    ctx.translate(left, top)
-    ctx.scale(scale, scale)
-    // 样式设置
-    ctx.strokeStyle = color
-    ctx.lineWidth = lineWidth
-    ctx.lineCap = 'round'
-    ctx.lineJoin = 'round'
-    ctx.beginPath()
-    // 回车折线
-    ctx.moveTo(8, 0)
-    ctx.lineTo(12, 0)
-    ctx.lineTo(12, 6)
-    ctx.lineTo(3, 6)
-    // 箭头向上
-    ctx.moveTo(3, 6)
-    ctx.lineTo(6, 3)
-    // 箭头向下
-    ctx.moveTo(3, 6)
-    ctx.lineTo(6, 9)
-    ctx.stroke()
-    ctx.closePath()
-    ctx.restore()
+    ctx.line({
+      color, lineWidth, lineCap: 'round', lineJoin: 'round'
+    })
+      .beforeDraw((c) => {
+        c.translate(left, top)
+        c.scale(scale, scale)
+      })
+       // 回车折线
+      .path(8, 0, 12, 0)
+      .path(12, 6)
+      .path(3, 6)
+       // 箭头向上
+      .path(3, 6, 6, 3)
+       // 箭头向下
+      .path(3, 6, 6, 9)
+      .draw()
   }
 }

--- a/src/editor/core/draw/particle/ListParticle.ts
+++ b/src/editor/core/draw/particle/ListParticle.ts
@@ -10,6 +10,7 @@ import { IRow, IRowElement } from '../../../interface/Row'
 import { getUUID } from '../../../utils'
 import { RangeManager } from '../../range/RangeManager'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class ListParticle {
   private draw: Draw
@@ -162,7 +163,7 @@ export class ListParticle {
   }
 
   public drawListStyle(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     row: IRow,
     position: IElementPosition
   ) {
@@ -219,10 +220,10 @@ export class ListParticle {
         text = `${listIndex! + 1}${KeyMap.PERIOD}`
       }
       if (!text) return
-      ctx.save()
-      ctx.font = `${defaultSize * scale}px ${defaultFont}`
-      ctx.fillText(text, x, y)
-      ctx.restore()
+      ctx.text(text, x, y, {
+        size: defaultSize * scale,
+        font: defaultFont
+      })
     }
   }
 }

--- a/src/editor/core/draw/particle/PageBreakParticle.ts
+++ b/src/editor/core/draw/particle/PageBreakParticle.ts
@@ -3,6 +3,7 @@ import { IEditorOption } from '../../../interface/Editor'
 import { IRowElement } from '../../../interface/Row'
 import { I18n } from '../../i18n/I18n'
 import { Draw } from '../Draw'
+import { CERenderingContext, FontProperty, LineProperty } from '../../../interface/CERenderingContext'
 
 export class PageBreakParticle {
   private draw: Draw
@@ -16,7 +17,7 @@ export class PageBreakParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
@@ -30,25 +31,23 @@ export class PageBreakParticle {
     const elementWidth = element.width! * scale
     const offsetY =
       this.draw.getDefaultBasicRowMarginHeight() * defaultRowMargin
-    ctx.save()
-    ctx.font = `${size}px ${font}`
-    const textMeasure = ctx.measureText(displayName)
+    const textMeasure = ctx.measureText(displayName, {
+      font, size
+    })
     const halfX = (elementWidth - textMeasure.width) / 2
     // 线段
-    ctx.setLineDash(lineDash)
-    ctx.translate(0, 0.5 + offsetY)
-    ctx.beginPath()
-    ctx.moveTo(x, y)
-    ctx.lineTo(x + halfX, y)
-    ctx.moveTo(x + halfX + textMeasure.width, y)
-    ctx.lineTo(x + elementWidth, y)
-    ctx.stroke()
+    const lineProp: LineProperty = {
+      lineDash
+    }
+    ctx.line(lineProp)
+      .beforeDraw(c=>c.translate(0, 0.5 + offsetY))
+      .path(x,y, x + halfX, y)
+      .path(x + halfX + textMeasure.width, y,x + elementWidth, y)
+      .draw()
     // 文字
-    ctx.fillText(
-      displayName,
-      x + halfX,
-      y + textMeasure.actualBoundingBoxAscent - size / 2
-    )
-    ctx.restore()
+    const fontProp: FontProperty = {
+      font, size, translate: [0, 0.5 + offsetY]
+    }
+    ctx.text(displayName, x + halfX, y + textMeasure.actualBoundingBoxAscent - size / 2, fontProp)
   }
 }

--- a/src/editor/core/draw/particle/RadioParticle.ts
+++ b/src/editor/core/draw/particle/RadioParticle.ts
@@ -5,9 +5,10 @@ import { IEditorOption } from '../../../interface/Editor'
 import { IElement } from '../../../interface/Element'
 import { IRow, IRowElement } from '../../../interface/Row'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 interface IRadioRenderOption {
-  ctx: CanvasRenderingContext2D
+  ctx: CERenderingContext
   x: number
   y: number
   row: IRow
@@ -78,22 +79,15 @@ export class RadioParticle {
     const top = Math.round(y - metrics.height + lineWidth)
     const width = metrics.width - gap * 2 * scale
     const height = metrics.height
-    ctx.save()
-    ctx.beginPath()
-    ctx.translate(0.5, 0.5)
     // 边框
-    ctx.strokeStyle = radio?.value ? fillStyle : strokeStyle
-    ctx.lineWidth = lineWidth
-    ctx.arc(left + width / 2, top + height / 2, width / 2, 0, Math.PI * 2)
-    ctx.stroke()
+    ctx.circle(left + width / 2, top + height / 2, width / 2, {
+      translate: [0.5, 0.5], color: radio?.value ? fillStyle : strokeStyle, lineWidth
+    })
     // 填充选中色
     if (radio?.value) {
-      ctx.beginPath()
-      ctx.fillStyle = fillStyle
-      ctx.arc(left + width / 2, top + height / 2, width / 3, 0, Math.PI * 2)
-      ctx.fill()
+      ctx.circle(left + width / 2, top + height / 2, width / 3, {
+        translate: [0.5, 0.5], fillColor: fillStyle
+      })
     }
-    ctx.closePath()
-    ctx.restore()
   }
 }

--- a/src/editor/core/draw/particle/SeparatorParticle.ts
+++ b/src/editor/core/draw/particle/SeparatorParticle.ts
@@ -2,6 +2,7 @@ import { DeepRequired } from '../../../interface/Common'
 import { IEditorOption } from '../../../interface/Editor'
 import { IRowElement } from '../../../interface/Row'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class SeparatorParticle {
   private options: DeepRequired<IEditorOption>
@@ -11,27 +12,28 @@ export class SeparatorParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
   ) {
-    ctx.save()
     const {
       scale,
       separator: { lineWidth, strokeStyle }
     } = this.options
-    ctx.lineWidth = lineWidth * scale
-    ctx.strokeStyle = element.color || strokeStyle
-    if (element.dashArray?.length) {
-      ctx.setLineDash(element.dashArray)
+
+    const width = lineWidth * scale
+    const lineProp = {
+      lineWidth: width,
+      color: element.color || strokeStyle,
+      lineDash: element.dashArray
     }
+
     const offsetY = Math.round(y) // 四舍五入避免绘制模糊
-    ctx.translate(0, ctx.lineWidth / 2)
-    ctx.beginPath()
-    ctx.moveTo(x, offsetY)
-    ctx.lineTo(x + element.width! * scale, offsetY)
-    ctx.stroke()
-    ctx.restore()
+
+    ctx.line(lineProp)
+      .beforeDraw(v => v.translate(0, width/2))
+      .path(x, offsetY, x + element.width! * scale, offsetY)
+      .draw()
   }
 }

--- a/src/editor/core/draw/particle/SubscriptParticle.ts
+++ b/src/editor/core/draw/particle/SubscriptParticle.ts
@@ -1,4 +1,5 @@
 import { IRowElement } from '../../../interface/Row'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class SubscriptParticle {
   // 向下偏移字高的一半
@@ -7,17 +8,13 @@ export class SubscriptParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
   ) {
-    ctx.save()
-    ctx.font = element.style
-    if (element.color) {
-      ctx.fillStyle = element.color
-    }
-    ctx.fillText(element.value, x, y + this.getOffsetY(element))
-    ctx.restore()
+    ctx.text(element.value, x, y + this.getOffsetY(element), {
+      font: element.style, color: element.color
+    })
   }
 }

--- a/src/editor/core/draw/particle/SuperscriptParticle.ts
+++ b/src/editor/core/draw/particle/SuperscriptParticle.ts
@@ -1,4 +1,5 @@
 import { IRowElement } from '../../../interface/Row'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class SuperscriptParticle {
   // 向上偏移字高的一半
@@ -7,17 +8,13 @@ export class SuperscriptParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
   ) {
-    ctx.save()
-    ctx.font = element.style
-    if (element.color) {
-      ctx.fillStyle = element.color
-    }
-    ctx.fillText(element.value, x, y + this.getOffsetY(element))
-    ctx.restore()
+    ctx.text(element.value, x, y + this.getOffsetY(element), {
+      font: element.style, color: element.color
+    })
   }
 }

--- a/src/editor/core/draw/particle/TextParticle.ts
+++ b/src/editor/core/draw/particle/TextParticle.ts
@@ -7,6 +7,7 @@ import { DeepRequired } from '../../../interface/Common'
 import { IRowElement } from '../../../interface/Row'
 import { ITextMetrics } from '../../../interface/Text'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export interface IMeasureWordResult {
   width: number
@@ -17,7 +18,7 @@ export class TextParticle {
   private draw: Draw
   private options: DeepRequired<IEditorOption>
 
-  private ctx: CanvasRenderingContext2D
+  private ctx: CERenderingContext
   private curX: number
   private curY: number
   private text: string
@@ -37,20 +38,14 @@ export class TextParticle {
   }
 
   public measureBasisWord(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     font: string
   ): ITextMetrics {
-    ctx.save()
-    ctx.font = font
-    const textMetrics = this.measureText(ctx, {
-      value: METRICS_BASIS_TEXT
-    })
-    ctx.restore()
-    return textMetrics
+    return ctx.measureText(METRICS_BASIS_TEXT, {font})
   }
 
   public measureWord(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     elementList: IElement[],
     curIndex: number
   ): IMeasureWordResult {
@@ -77,7 +72,7 @@ export class TextParticle {
   }
 
   public measurePunctuationWidth(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IElement
   ): number {
     if (!element || !PUNCTUATION_LIST.includes(element.value)) return 0
@@ -85,7 +80,7 @@ export class TextParticle {
   }
 
   public measureText(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IElement
   ): ITextMetrics {
     // 优先使用自定义字宽设置
@@ -102,7 +97,7 @@ export class TextParticle {
         fontBoundingBoxDescent: textMetrics.fontBoundingBoxDescent
       }
     }
-    const id = `${element.value}${ctx.font}`
+    const id = `${element.value}${ctx.getFont()}`
     const cacheTextMetrics = this.cacheMeasureText.get(id)
     if (cacheTextMetrics) {
       return cacheTextMetrics
@@ -118,7 +113,7 @@ export class TextParticle {
   }
 
   public record(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IRowElement,
     x: number,
     y: number
@@ -157,10 +152,9 @@ export class TextParticle {
 
   private _render() {
     if (!this.text || !~this.curX || !~this.curX) return
-    this.ctx.save()
-    this.ctx.font = this.curStyle
-    this.ctx.fillStyle = this.curColor || this.options.defaultColor
-    this.ctx.fillText(this.text, this.curX, this.curY)
-    this.ctx.restore()
+    this.ctx.text(this.text, this.curX, this.curY, {
+      font: this.curStyle,
+      color: this.curColor || this.options.defaultColor,
+    })
   }
 }

--- a/src/editor/core/draw/particle/latex/LaTexParticle.ts
+++ b/src/editor/core/draw/particle/latex/LaTexParticle.ts
@@ -1,6 +1,7 @@
 import { IElement } from '../../../../interface/Element'
 import { ImageParticle } from '../ImageParticle'
 import { LaTexSVG, LaTexUtils } from './utils/LaTexUtils'
+import { CERenderingContext } from '../../../../interface/CERenderingContext'
 
 export class LaTexParticle extends ImageParticle {
   public static convertLaTextToSVG(laTex: string): LaTexSVG {
@@ -13,7 +14,7 @@ export class LaTexParticle extends ImageParticle {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     element: IElement,
     x: number,
     y: number

--- a/src/editor/core/draw/richtext/AbstractRichText.ts
+++ b/src/editor/core/draw/richtext/AbstractRichText.ts
@@ -1,5 +1,6 @@
 import { TextDecorationStyle } from '../../../dataset/enum/Text'
 import { IElementFillRect } from '../../../interface/Element'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export abstract class AbstractRichText {
   protected fillRect: IElementFillRect
@@ -23,7 +24,7 @@ export abstract class AbstractRichText {
   }
 
   public recordFillInfo(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     x: number,
     y: number,
     width: number,
@@ -55,5 +56,5 @@ export abstract class AbstractRichText {
     this.fillDecorationStyle = decorationStyle
   }
 
-  public abstract render(ctx: CanvasRenderingContext2D): void
+  public abstract render(ctx: CERenderingContext): void
 }

--- a/src/editor/core/draw/richtext/Highlight.ts
+++ b/src/editor/core/draw/richtext/Highlight.ts
@@ -1,6 +1,7 @@
 import { AbstractRichText } from './AbstractRichText'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Highlight extends AbstractRichText {
   private options: Required<IEditorOption>
@@ -10,15 +11,11 @@ export class Highlight extends AbstractRichText {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     if (!this.fillRect.width) return
     const { highlightAlpha } = this.options
     const { x, y, width, height } = this.fillRect
-    ctx.save()
-    ctx.globalAlpha = highlightAlpha
-    ctx.fillStyle = this.fillColor!
-    ctx.fillRect(x, y, width, height)
-    ctx.restore()
+    ctx.fillRect(x, y, width, height,  { fillColor: this.fillColor, alpha: highlightAlpha})
     this.clearFillInfo()
   }
 }

--- a/src/editor/core/draw/richtext/Strikeout.ts
+++ b/src/editor/core/draw/richtext/Strikeout.ts
@@ -1,6 +1,7 @@
 import { AbstractRichText } from './AbstractRichText'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
+import { CERenderingContext } from '../../../interface/CERenderingContext'
 
 export class Strikeout extends AbstractRichText {
   private options: Required<IEditorOption>
@@ -10,19 +11,14 @@ export class Strikeout extends AbstractRichText {
     this.options = draw.getOptions()
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     if (!this.fillRect.width) return
     const { scale, strikeoutColor } = this.options
     const { x, y, width } = this.fillRect
-    ctx.save()
-    ctx.lineWidth = scale
-    ctx.strokeStyle = strikeoutColor
     const adjustY = y + 0.5 // 从1处渲染，避免线宽度等于3
-    ctx.beginPath()
-    ctx.moveTo(x, adjustY)
-    ctx.lineTo(x + width, adjustY)
-    ctx.stroke()
-    ctx.restore()
+    ctx.line({
+      lineWidth: scale, color: strikeoutColor
+    }).path(x, adjustY, x+width, adjustY).draw()
     this.clearFillInfo()
   }
 }

--- a/src/editor/core/draw/richtext/Underline.ts
+++ b/src/editor/core/draw/richtext/Underline.ts
@@ -2,6 +2,7 @@ import { AbstractRichText } from './AbstractRichText'
 import { IEditorOption } from '../../../interface/Editor'
 import { Draw } from '../Draw'
 import { DashType, TextDecorationStyle } from '../../../dataset/enum/Text'
+import { CERenderingContext, LineProperty } from '../../../interface/CERenderingContext'
 
 export class Underline extends AbstractRichText {
   private options: Required<IEditorOption>
@@ -13,94 +14,89 @@ export class Underline extends AbstractRichText {
 
   // 下划线
   private _drawLine(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     startX: number,
     startY: number,
     width: number,
-    dashType?: DashType
+    lineProp: LineProperty,
+    dashType?: DashType,
   ) {
     const endX = startX + width
-    ctx.beginPath()
     switch (dashType) {
       case DashType.DASHED:
         // 长虚线- - - - - -
-        ctx.setLineDash([3, 1])
+        lineProp.lineDash = [3, 1]
         break
       case DashType.DOTTED:
         // 点虚线 . . . . . .
-        ctx.setLineDash([1, 1])
+        lineProp.lineDash = [1, 1]
         break
     }
-    ctx.moveTo(startX, startY)
-    ctx.lineTo(endX, startY)
-    ctx.stroke()
+    ctx.line(lineProp).path(startX, startY, endX, startY).draw()
   }
 
   // 双实线
   private _drawDouble(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     startX: number,
     startY: number,
-    width: number
+    width: number,
+    lineProp: LineProperty
   ) {
     const SPACING = 3 // 双实线间距
     const endX = startX + width
     const endY = startY + SPACING * this.options.scale
-    ctx.beginPath()
-    ctx.moveTo(startX, startY)
-    ctx.lineTo(endX, startY)
-    ctx.stroke()
-    ctx.beginPath()
-    ctx.moveTo(startX, endY)
-    ctx.lineTo(endX, endY)
-    ctx.stroke()
+
+    const drawer = ctx.line(lineProp)
+    drawer.path(startX, startY, endX, startY)
+      .path(startX, endY, endX, endY).draw()
   }
 
   // 波浪线
   private _drawWave(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     startX: number,
     startY: number,
-    width: number
+    width: number,
+    lineProp: LineProperty
   ) {
     const { scale } = this.options
     const AMPLITUDE = 1.2 * scale // 振幅
     const FREQUENCY = 1 / scale // 频率
     const adjustY = startY + 2 * AMPLITUDE // 增加2倍振幅
-    ctx.beginPath()
+    const drawer = ctx.line(lineProp)
     for (let x = 0; x < width; x++) {
       const y = AMPLITUDE * Math.sin(FREQUENCY * x)
-      ctx.lineTo(startX + x, adjustY + y)
+      drawer.path(startX + x, adjustY + y)
     }
-    ctx.stroke()
+    drawer.draw()
   }
 
-  public render(ctx: CanvasRenderingContext2D) {
+  public render(ctx: CERenderingContext) {
     if (!this.fillRect.width) return
     const { underlineColor, scale } = this.options
     const { x, y, width } = this.fillRect
-    ctx.save()
-    ctx.strokeStyle = this.fillColor || underlineColor
-    ctx.lineWidth = scale
-    const adjustY = Math.floor(y + 2 * ctx.lineWidth) + 0.5 // +0.5从1处渲染，避免线宽度等于3
+    const prop = {
+      color: this.fillColor || underlineColor, lineWidth: scale
+    }
+    const adjustY = Math.floor(y + 2 * scale) + 0.5 // +0.5从1处渲染，避免线宽度等于3
     switch (this.fillDecorationStyle) {
       case TextDecorationStyle.WAVY:
-        this._drawWave(ctx, x, adjustY, width)
+        this._drawWave(ctx, x, adjustY, width, prop)
         break
       case TextDecorationStyle.DOUBLE:
-        this._drawDouble(ctx, x, adjustY, width)
+        this._drawDouble(ctx, x, adjustY, width, prop)
         break
       case TextDecorationStyle.DASHED:
-        this._drawLine(ctx, x, adjustY, width, DashType.DASHED)
+        this._drawLine(ctx, x, adjustY, width, prop, DashType.DASHED)
         break
       case TextDecorationStyle.DOTTED:
-        this._drawLine(ctx, x, adjustY, width, DashType.DOTTED)
+        this._drawLine(ctx, x, adjustY, width, prop, DashType.DOTTED)
         break
       default:
-        this._drawLine(ctx, x, adjustY, width)
+        this._drawLine(ctx, x, adjustY, width, prop)
         break
     }
-    ctx.restore()
     this.clearFillInfo()
   }
 }

--- a/src/editor/core/range/RangeManager.ts
+++ b/src/editor/core/range/RangeManager.ts
@@ -21,6 +21,7 @@ import { EventBus } from '../event/eventbus/EventBus'
 import { HistoryManager } from '../history/HistoryManager'
 import { Listener } from '../listener/Listener'
 import { Position } from '../position/Position'
+import { CERenderingContext } from '../../interface/CERenderingContext'
 
 export class RangeManager {
   private draw: Draw
@@ -655,17 +656,16 @@ export class RangeManager {
   }
 
   public render(
-    ctx: CanvasRenderingContext2D,
+    ctx: CERenderingContext,
     x: number,
     y: number,
     width: number,
     height: number
   ) {
-    ctx.save()
-    ctx.globalAlpha = this.options.rangeAlpha
-    ctx.fillStyle = this.options.rangeColor
-    ctx.fillRect(x, y, width, height)
-    ctx.restore()
+    ctx.fillRect(x, y, width, height, {
+      alpha: this.options.rangeAlpha,
+      fillColor: this.options.rangeColor
+    })
   }
 
   public toString(): string {

--- a/src/editor/interface/CERenderingContext.ts
+++ b/src/editor/interface/CERenderingContext.ts
@@ -1,0 +1,82 @@
+import { ITextMetrics } from './Text'
+import { Draw } from '../core/draw/Draw'
+
+export interface CERenderingContext {
+
+  drawImage(value: HTMLImageElement | string, dx: number, dy: number, width: number, height: number): void
+
+  fillRect(x: number, y: number, width: number, height: number, prop: LineProperty): void
+
+  strokeRect(x: number, y: number, width: number, height: number, prop: LineProperty): void
+
+  line(prop: LineProperty): LineDrawer
+
+  circle(x: number, y: number, r: number, prop: LineProperty): void
+
+  translate(x: number, y: number): void
+
+  scale(x: number, y: number): void
+
+  measureText(text: string, prop?: FontProperty): ITextMetrics
+
+  text(text: string, x: number, y: number, prop: FontProperty): void
+
+  initPageContext(scale: number, direction: TextDirection): void
+
+  setGlobalAlpha(alpha: number): void
+
+  getGlobalAlpha(): number
+
+  getFont(): string
+
+  addWatermark(data: HTMLCanvasElement, area: DrawArea): void
+  addWatermarkSingle(data: string, draw: Draw, prop: FontProperty, metrics: ITextMetrics): void
+
+  cleanPage(pageWidth: number, pageHeight: number): void;
+}
+
+export interface LineDrawer {
+  path(x1: number, y1: number, x2?: number, y2?: number): LineDrawer
+
+  beforeDraw(action: (ctx: CERenderingContext) => void): LineDrawer
+
+  draw(): void
+}
+
+export interface LineProperty {
+  color?: string
+  fillColor?: string
+  alpha?: number
+  lineWidth?: number
+  lineDash?: number[],
+  lineCap?: 'round' | 'butt' | 'square',
+  lineJoin?: 'bevel' | 'miter' | 'round'
+  translate?: [number, number]
+}
+
+export type TextBaseline = 'alphabetic' | 'bottom' | 'hanging' | 'ideographic' | 'middle' | 'top';
+export type TextAlign = 'left' | 'center' | 'right'
+export type TextDirection = 'ltr' | 'rtl';
+
+
+export interface FontProperty {
+  font?: string
+  size?: number
+  alpha?: number
+  textAlign?: TextAlign
+  textBaseline?: TextBaseline
+  color?: string
+  maxWidth?: number
+  fontStyle?: string
+  fontWeight?: number
+  rotate?: number
+  translate?: [number, number]
+}
+
+export interface DrawArea {
+  startX: number
+  startY: number
+  width: number
+  height: number
+  alpha?: number
+}

--- a/src/editor/interface/Draw.ts
+++ b/src/editor/interface/Draw.ts
@@ -2,6 +2,7 @@ import { ImageDisplay } from '../dataset/enum/Common'
 import { EditorMode, EditorZone } from '../dataset/enum/Editor'
 import { IElement, IElementPosition } from './Element'
 import { IRow } from './Row'
+import jsPDF from 'jspdf'
 
 export interface IDrawOption {
   curIndex?: number
@@ -76,4 +77,8 @@ export interface IComputeRowListPayload {
   pageHeight?: number
   mainOuterHeight?: number
   surroundElementList?: IElement[]
+}
+
+export interface IGetPdfOption {
+  beforeExport?: (doc: jsPDF) => void
 }

--- a/src/editor/pdf/PdfCERenderingContext.ts
+++ b/src/editor/pdf/PdfCERenderingContext.ts
@@ -1,0 +1,365 @@
+import { CERenderingContext, DrawArea, FontProperty, LineDrawer, LineProperty } from '../interface/CERenderingContext'
+import { getUUID } from '../utils'
+import { ITextMetrics } from '../interface/Text'
+import { Draw } from '../core/draw/Draw'
+import jsPDF from 'jspdf'
+
+
+const canvas = document.createElement('canvas')
+const canvasCtx = canvas.getContext('2d')!
+const svgDataPrefix = 'data:image/svg+xml;base64,'
+
+export class PdfCERenderingContext implements CERenderingContext {
+
+  private textDirection: any = {}
+  private promises: Promise<any>[] = []
+
+  constructor(private pageNo: number, private doc: jsPDF) {
+  }
+
+  get currentPage() {
+    return this.pageNo
+  }
+
+  get pdf() {
+    return this.doc
+  }
+
+  get ctx() {
+    return this.doc.context2d
+  }
+
+  public loadOver() {
+    return Promise.all(this.promises)
+  }
+
+  public drawImage(value: HTMLImageElement | string, dx: number, dy: number, width: number, height: number): void {
+    if (typeof value === 'string') {
+      const pr = this._getSvgCanvasFromStr(value, width, height).then(v => {
+        this._execRestore(() => {
+          this.doc.setGState(this.doc.GState({ opacity: 1, 'stroke-opacity': 1 }))
+          this.doc.addImage(v, '', dx, dy, width, height, '', 'FAST')
+        })
+      })
+      this.promises.push(pr)
+    } else {
+      if (value.src && value.src.startsWith(svgDataPrefix)) {
+        const pr = this._getSvgCanvasFromImgEle(value, width, height).then(v => {
+          this._execRestore(() => {
+            this.doc.setGState(this.doc.GState({ opacity: 1, 'stroke-opacity': 1 }))
+            this.doc.addImage(v, '', dx, dy, width, height, '', 'FAST')
+          })
+        })
+        this.promises.push(pr)
+      } else {
+        this._execRestore(() => {
+          this.doc.setGState(this.doc.GState({ opacity: 1, 'stroke-opacity': 1 }))
+          this.doc.addImage(value, '', dx, dy, width, height, '', 'FAST')
+        })
+      }
+    }
+  }
+
+  private _getSvgCanvasFromImgEle(img: HTMLImageElement, width: number, height: number): Promise<string|HTMLImageElement> {
+
+    if (img.src.startsWith(svgDataPrefix)) {
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')!
+      ctx.clearRect(0,0,width, height)
+      if (img.complete) {
+        ctx.drawImage(img, 0, 0, width, height)
+        return Promise.resolve(canvas.toDataURL('image/png'))
+      } else {
+        return new Promise(resolve => {
+          img.onload = () => {
+            ctx.drawImage(img, 0, 0, width, height)
+            resolve(canvas.toDataURL('image/png'))
+          }
+        })
+      }
+    } else {
+      if (img.complete) {
+        return Promise.resolve(img)
+      } else {
+        return  new Promise((resolve) => {
+          if (img.complete) {
+            resolve(img)
+          } else {
+            img.onload = () => {
+              resolve(img)
+            }
+          }
+        })
+      }
+    }
+  }
+
+  private _getSvgCanvasFromStr(svgData: string, width: number, height: number): Promise<string> {
+    const cvs = document.createElement('canvas')
+    cvs.width = width
+    cvs.height = height
+    if (!svgData) {
+      return Promise.resolve(cvs.toDataURL('image/png'))
+    }
+
+    const img = new Image()
+    const ctx = cvs.getContext('2d')!
+    ctx.clearRect(0, 0, width, height)
+    return new Promise<string>((resolve) => {
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0, width, height)
+        resolve(cvs.toDataURL('image/png'))
+      }
+      if (svgData.startsWith('<svg')) {
+        img.innerHTML = svgData
+      }
+      if (svgData.startsWith(svgDataPrefix)) {
+        img.src = svgData
+      }
+
+    })
+  }
+
+  fillRect(x: number, y: number, width: number, height: number, prop: LineProperty): void {
+    this._execRestore(() => {
+      if (prop.translate) {
+        this.translate(...prop.translate)
+      }
+      this.doc.setFillColor(prop.fillColor ?? '#fff')
+      this.doc.setGState(this.doc.GState({ opacity: prop.alpha ?? 1 }))
+      this.doc.rect(x, y, width, height, 'F')
+    })
+  }
+
+  strokeRect(x: number, y: number, width: number, height: number, prop: LineProperty): void {
+    this._execRestore(() => {
+      if (prop.translate) {
+        this.translate(...prop.translate)
+      }
+      this.doc.setDrawColor(prop.fillColor ?? '#000')
+      this.doc.setGState(this.doc.GState({ 'stroke-opacity': prop.alpha ?? 1 }))
+      this.doc.rect(x, y, width, height, 'S')
+    })
+  }
+
+  circle(x: number, y: number, r: number, prop: LineProperty): void {
+
+    this._execRestore(() => {
+
+      let style
+      if (prop.fillColor && prop.color) {
+        style = 'FD'
+        this.doc.setFillColor(prop.fillColor)
+        this.doc.setDrawColor(prop.color)
+      } else {
+        if (prop.fillColor) {
+          style = 'F'
+          this.doc.setFillColor(prop.fillColor)
+        }
+        if (prop.color) {
+          style = 'S'
+          this.doc.setDrawColor(prop.color)
+        }
+      }
+
+      this.doc.circle(x, y, r, style)
+    })
+  }
+
+
+  line(prop: LineProperty): LineDrawer {
+    return new PdfRenderingContextLineDrawer(this, prop)
+  }
+
+  text(text: string, x: number, y: number, prop: FontProperty): void {
+    this._execRestore(() => {
+      if (prop.font) this.ctx.font = prop.font
+      if (prop.size) this.doc.setFontSize(prop.size)
+      if (prop.color) this.doc.setTextColor(prop.color)
+      if (prop.translate && prop.translate.length === 2) this.translate(...prop.translate)
+      if (prop.alpha || prop.alpha === 0) this.doc.setGState(this.doc.GState({ opacity: prop.alpha ?? 1 }))
+      this.doc.text(text, x, y, {
+        align: prop.textAlign,
+        baseline: prop.textBaseline,
+        ...this.textDirection
+      })
+    })
+  }
+
+  private _execRestore(exec: () => void): void {
+    const pn = this.doc.getCurrentPageInfo().pageNumber
+    this.doc.setPage(this.pageNo)
+    this.doc.saveGraphicsState()
+    try {
+      exec()
+    } finally {
+      this.doc.setPage(pn)
+      this.doc.restoreGraphicsState()
+    }
+  }
+
+  translate(x: number, y: number): void {
+    // https://stackoverflow.com/questions/77509324/how-to-use-setcurrenttransformationmatrix-in-jspdf
+    // https://github.com/parallax/jsPDF/blob/ddbfc0f0250ca908f8061a72fa057116b7613e78/jspdf.js#L791
+    const matrix = this.doc.Matrix(1.0, 0.0, 0.0, 1.0, x / (96 / 72), -y / (96 / 72))
+    this.doc.setCurrentTransformationMatrix(matrix)
+  }
+
+  scale(scaleWidth: number, scaleHeight: number): void {
+    const matrix = this.doc.Matrix(scaleWidth, 0.0, 0.0, scaleHeight, 0.0, 0.0)
+    this.doc.setCurrentTransformationMatrix(matrix)
+  }
+
+  initPageContext(scale: number, direction: string): void {
+    const matrix = this.doc.Matrix(scale, 0.0, 0.0, scale, 0.0, 0.0)
+    this.doc.setCurrentTransformationMatrix(matrix)
+    if (direction === 'rtl') {
+      this.pdf.setR2L(true)
+    }
+  }
+
+  setGlobalAlpha(alpha: number): void {
+    // pdf
+    this.ctx.globalAlpha = alpha
+  }
+
+  getGlobalAlpha(): number {
+    return this.ctx.globalAlpha
+  }
+
+  // 这个方法返回值不准确，jspdf 中没有打到对应的接口
+  measureText(text: string, prop: FontProperty): ITextMetrics {
+    let font
+    if (prop && prop.size && prop.font) {
+      font = `${prop.fontStyle ?? ''} ${prop.fontWeight ?? ''} ${prop.size ? `${prop.size}px` : ''} ${prop.font ?? ''}`
+    }
+
+    if (font && font.trim().length > 0) {
+      canvasCtx.save()
+      canvasCtx.font = font
+    }
+    const metrics = canvasCtx.measureText(text)
+    if (font && font.trim().length > 0) {
+      canvasCtx.restore()
+    }
+    return metrics
+  }
+
+  getFont(): string {
+    const font = this.doc.getFont()
+    const size = this.doc.getFontSize()
+    return `${size}px ${font.fontStyle} ${font.fontName}`
+  }
+
+  addWatermark(data: HTMLCanvasElement, area: DrawArea): void {
+
+    this._execRestore(() => {
+
+      const { startX, startY, height, width } = area
+      const dataW = data.width
+      const dataH = data.height
+
+      const y = Math.ceil(height / dataH)
+      const x = Math.ceil(width / dataW)
+      if (area.alpha || area.alpha === 0) this.doc.setGState(this.doc.GState({ opacity: area.alpha ?? 1 }))
+      const alias = getUUID()
+      for (let i = 0; i < y; i++) {
+        for (let j = 0; j < x; j++) {
+          this.pdf.addImage({
+            imageData: data.toDataURL('image/png'), x: startX + j * dataW, y: startY + i * dataH, width: dataW, height: dataH, alias
+          })
+        }
+      }
+    })
+  }
+
+  addWatermarkSingle(data: string, draw: Draw, prop: FontProperty, metrics: ITextMetrics): void {
+    const width = draw.getWidth()
+    const height = draw.getHeight()
+    const rotatedTextWidth = metrics.width * Math.sin(45)
+    const rotatedTextOffset = metrics.actualBoundingBoxAscent * Math.sin(45)
+    const tx = (width - rotatedTextWidth) / 2 + (rotatedTextOffset)
+    const ty = (height - rotatedTextWidth) / 2 + rotatedTextWidth - (rotatedTextOffset / 2)
+    this._execRestore(() => {
+      if (prop.font) this.ctx.font = `${prop.size ?? 120}px ${prop.font}`
+      if (prop.color) this.doc.setTextColor(prop.color)
+      if (prop.alpha || prop.alpha === 0) this.doc.setGState(this.doc.GState({ opacity: prop.alpha ?? 1 }))
+
+      this.doc.text(data, tx, ty, undefined, 45)
+    })
+  }
+
+  cleanPage(): void {
+    this.doc.deletePage(this.pageNo - 1)
+    this.doc.insertPage(this.pageNo - 1)
+  }
+}
+
+export class PdfRenderingContextLineDrawer implements LineDrawer {
+  private actions: (() => void)[] = []
+  private _beforeDraw: ((ctx: CERenderingContext) => void) | null = null
+  private readonly alpha: number
+  private readonly lineWidth: number
+  private readonly strikeoutColor: string
+
+  constructor(private ctx: PdfCERenderingContext, private prop: LineProperty) {
+    this.alpha = this.prop.alpha ?? 1
+    this.lineWidth = this.prop.lineWidth ?? 1
+    this.strikeoutColor = this.prop.color ?? '#000'
+  }
+
+  beforeDraw(action: (ctx: CERenderingContext) => void): LineDrawer {
+    this._beforeDraw = action
+    return this
+  }
+
+
+  draw(): void {
+    if (!this.actions.length) {
+      return
+    }
+    const pn = this.ctx.pdf.getCurrentPageInfo().pageNumber
+    const doc = this.ctx.pdf
+    doc.setPage(this.ctx.currentPage)
+    doc.saveGraphicsState()
+    doc.setLineWidth(this.lineWidth)
+    doc.setGState(doc.GState({ 'stroke-opacity': this.alpha }))
+    doc.setDrawColor(this.strikeoutColor)
+    if (this.prop.lineCap) {
+      doc.setLineCap(this.prop.lineCap)
+    }
+    if (this.prop.lineJoin) {
+      doc.setLineJoin(this.prop.lineJoin)
+    }
+    if (this.prop.lineDash) {
+      doc.setLineDashPattern(this.prop.lineDash, 0)
+    }
+    try {
+      if (typeof this._beforeDraw === 'function') {
+        this._beforeDraw(this.ctx)
+      }
+      for (let i = 0; i < this.actions.length; i++) {
+        this.actions[i]()
+      }
+    } finally {
+      doc.setPage(pn)
+      doc.restoreGraphicsState()
+    }
+  }
+
+  path(x1: number, y1: number, x2?: number, y2?: number): LineDrawer {
+    this.actions.push(() => {
+      if (!x2 || !y2) {
+        // 传两个参数
+        this.ctx.pdf.lineTo(x1, y1)
+      } else {
+        this.ctx.pdf.line(x1, y1, x2, y2, 'S')
+      }
+    })
+    return this
+  }
+
+}
+

--- a/src/editor/types/index.d.ts
+++ b/src/editor/types/index.d.ts
@@ -3,3 +3,7 @@ interface CanvasRenderingContext2D {
   letterSpacing: string
   wordSpacing: string
 }
+
+interface FontFaceSet {
+  add: (font: FontFace) => void
+}

--- a/src/editor/types/jspdf.d.ts
+++ b/src/editor/types/jspdf.d.ts
@@ -1,0 +1,7 @@
+import jspdf from 'jspdf'
+
+declare  global {
+  interface Window {
+    jspdf: {jsPDF: typeof jspdf};
+  }
+}

--- a/src/pdf-main.ts
+++ b/src/pdf-main.ts
@@ -1,0 +1,1798 @@
+import { commentList, data, options } from './mock'
+import './style.css'
+import prism from 'prismjs'
+import Editor, {
+  BlockType,
+  Command,
+  ControlState,
+  ControlType,
+  EditorMode,
+  EditorZone,
+  ElementType,
+  IBlock,
+  IElement,
+  KeyMap,
+  ListStyle,
+  ListType,
+  PageMode,
+  PaperDirection,
+  RowFlex,
+  splitText,
+  TextDecorationStyle,
+  TitleLevel
+} from './editor'
+import { Dialog } from './components/dialog/Dialog'
+import { formatPrismToken } from './utils/prism'
+import { Signature } from './components/signature/Signature'
+import { debounce } from './utils'
+
+window.onload = function() {
+  const fontDom = document.querySelector<HTMLDivElement>('.menu-item__font')!
+  fontDom.classList.add('disable')
+  const myFont = new FontFace('sim-fang', 'url("/canvas-editor/fonts/simfang.ttf")')
+
+  myFont.load().then(font => {
+    document.fonts.add(font)
+    fontDom.classList.remove('disable')
+  })
+  const isApple =
+    typeof navigator !== 'undefined' && /Mac OS X/.test(navigator.userAgent)
+
+  // 1. 初始化编辑器
+  const container = document.querySelector<HTMLDivElement>('.editor')!
+  const instance = new Editor(
+    container,
+    {
+      header: [
+        {
+          value: '第一人民医院',
+          size: 32,
+          rowFlex: RowFlex.CENTER
+        },
+        {
+          value: '\n门诊病历',
+          size: 18,
+          rowFlex: RowFlex.CENTER
+        },
+        {
+          value: '\n',
+          type: ElementType.SEPARATOR
+        }
+      ],
+      main: data,
+      footer: [
+        {
+          value: 'canvas-editor',
+          size: 12
+        }
+      ]
+    },
+    options
+  )
+  console.log('实例: ', instance)
+  // cypress使用
+  Reflect.set(window, 'editor', instance)
+
+  // 菜单弹窗销毁
+  window.addEventListener(
+    'click',
+    evt => {
+      const visibleDom = document.querySelector('.visible')
+      if (!visibleDom || visibleDom.contains(<Node>evt.target)) return
+      visibleDom.classList.remove('visible')
+    },
+    {
+      capture: true
+    }
+  )
+
+  // 2. | 撤销 | 重做 | 格式刷 | 清除格式 |
+  const undoDom = document.querySelector<HTMLDivElement>('.menu-item__undo')!
+  undoDom.title = `撤销(${isApple ? '⌘' : 'Ctrl'}+Z)`
+  undoDom.onclick = function() {
+    console.log('undo')
+    instance.command.executeUndo()
+  }
+
+  const redoDom = document.querySelector<HTMLDivElement>('.menu-item__redo')!
+  redoDom.title = `重做(${isApple ? '⌘' : 'Ctrl'}+Y)`
+  redoDom.onclick = function() {
+    console.log('redo')
+    instance.command.executeRedo()
+  }
+
+  const painterDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__painter'
+  )!
+
+  let isFirstClick = true
+  let painterTimeout: number
+  painterDom.onclick = function() {
+    if (isFirstClick) {
+      isFirstClick = false
+      painterTimeout = window.setTimeout(() => {
+        console.log('painter-click')
+        isFirstClick = true
+        instance.command.executePainter({
+          isDblclick: false
+        })
+      }, 200)
+    } else {
+      window.clearTimeout(painterTimeout)
+    }
+  }
+
+  painterDom.ondblclick = function() {
+    console.log('painter-dblclick')
+    isFirstClick = true
+    window.clearTimeout(painterTimeout)
+    instance.command.executePainter({
+      isDblclick: true
+    })
+  }
+
+  document.querySelector<HTMLDivElement>('.menu-item__format')!.onclick =
+    function() {
+      console.log('format')
+      instance.command.executeFormat()
+    }
+
+  // 3. | 字体 | 字体变大 | 字体变小 | 加粗 | 斜体 | 下划线 | 删除线 | 上标 | 下标 | 字体颜色 | 背景色 |
+
+  const fontSelectDom = fontDom.querySelector<HTMLDivElement>('.select')!
+  const fontOptionDom = fontDom.querySelector<HTMLDivElement>('.options')!
+  fontDom.onclick = function() {
+    console.log('font')
+    fontOptionDom.classList.toggle('visible')
+  }
+  fontOptionDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    instance.command.executeFont(li.dataset.family!)
+  }
+
+  const sizeSetDom = document.querySelector<HTMLDivElement>('.menu-item__size')!
+  const sizeSelectDom = sizeSetDom.querySelector<HTMLDivElement>('.select')!
+  const sizeOptionDom = sizeSetDom.querySelector<HTMLDivElement>('.options')!
+  sizeSetDom.title = `设置字号`
+  sizeSetDom.onclick = function() {
+    console.log('size')
+    sizeOptionDom.classList.toggle('visible')
+  }
+  sizeOptionDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    instance.command.executeSize(Number(li.dataset.size!))
+  }
+
+  const sizeAddDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__size-add'
+  )!
+  sizeAddDom.title = `增大字号(${isApple ? '⌘' : 'Ctrl'}+[)`
+  sizeAddDom.onclick = function() {
+    console.log('size-add')
+    instance.command.executeSizeAdd()
+  }
+
+  const sizeMinusDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__size-minus'
+  )!
+  sizeMinusDom.title = `减小字号(${isApple ? '⌘' : 'Ctrl'}+])`
+  sizeMinusDom.onclick = function() {
+    console.log('size-minus')
+    instance.command.executeSizeMinus()
+  }
+
+  const boldDom = document.querySelector<HTMLDivElement>('.menu-item__bold')!
+  boldDom.title = `加粗(${isApple ? '⌘' : 'Ctrl'}+B)`
+  boldDom.onclick = function() {
+    console.log('bold')
+    instance.command.executeBold()
+  }
+
+  const italicDom =
+    document.querySelector<HTMLDivElement>('.menu-item__italic')!
+  italicDom.title = `斜体(${isApple ? '⌘' : 'Ctrl'}+I)`
+  italicDom.onclick = function() {
+    console.log('italic')
+    instance.command.executeItalic()
+  }
+
+  const underlineDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__underline'
+  )!
+  underlineDom.title = `下划线(${isApple ? '⌘' : 'Ctrl'}+U)`
+  const underlineOptionDom =
+    underlineDom.querySelector<HTMLDivElement>('.options')!
+  underlineDom.querySelector<HTMLSpanElement>('.select')!.onclick =
+    function() {
+      underlineOptionDom.classList.toggle('visible')
+    }
+  underlineDom.querySelector<HTMLElement>('i')!.onclick = function() {
+    console.log('underline')
+    instance.command.executeUnderline()
+    underlineOptionDom.classList.remove('visible')
+  }
+  underlineDom.querySelector<HTMLUListElement>('ul')!.onmousedown = function(
+    evt
+  ) {
+    const li = evt.target as HTMLLIElement
+    const decorationStyle = <TextDecorationStyle>li.dataset.decorationStyle
+    instance.command.executeUnderline({
+      style: decorationStyle
+    })
+    underlineOptionDom.classList.remove('visible')
+  }
+
+  const strikeoutDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__strikeout'
+  )!
+  strikeoutDom.onclick = function() {
+    console.log('strikeout')
+    instance.command.executeStrikeout()
+  }
+
+  const superscriptDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__superscript'
+  )!
+  superscriptDom.title = `上标(${isApple ? '⌘' : 'Ctrl'}+Shift+,)`
+  superscriptDom.onclick = function() {
+    console.log('superscript')
+    instance.command.executeSuperscript()
+  }
+
+  const subscriptDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__subscript'
+  )!
+  subscriptDom.title = `下标(${isApple ? '⌘' : 'Ctrl'}+Shift+.)`
+  subscriptDom.onclick = function() {
+    console.log('subscript')
+    instance.command.executeSubscript()
+  }
+
+  const colorControlDom = document.querySelector<HTMLInputElement>('#color')!
+  colorControlDom.oninput = function() {
+    instance.command.executeColor(colorControlDom.value)
+  }
+  const colorDom = document.querySelector<HTMLDivElement>('.menu-item__color')!
+  const colorSpanDom = colorDom.querySelector('span')!
+  colorDom.onclick = function() {
+    console.log('color')
+    colorControlDom.click()
+  }
+
+  const highlightControlDom =
+    document.querySelector<HTMLInputElement>('#highlight')!
+  highlightControlDom.oninput = function() {
+    instance.command.executeHighlight(highlightControlDom.value)
+  }
+  const highlightDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__highlight'
+  )!
+  const highlightSpanDom = highlightDom.querySelector('span')!
+  highlightDom.onclick = function() {
+    console.log('highlight')
+    highlightControlDom?.click()
+  }
+
+  const titleDom = document.querySelector<HTMLDivElement>('.menu-item__title')!
+  const titleSelectDom = titleDom.querySelector<HTMLDivElement>('.select')!
+  const titleOptionDom = titleDom.querySelector<HTMLDivElement>('.options')!
+  titleOptionDom.querySelectorAll('li').forEach((li, index) => {
+    li.title = `Ctrl+${isApple ? 'Option' : 'Alt'}+${index}`
+  })
+
+  titleDom.onclick = function() {
+    console.log('title')
+    titleOptionDom.classList.toggle('visible')
+  }
+  titleOptionDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const level = <TitleLevel>li.dataset.level
+    instance.command.executeTitle(level || null)
+  }
+
+  const leftDom = document.querySelector<HTMLDivElement>('.menu-item__left')!
+  leftDom.title = `左对齐(${isApple ? '⌘' : 'Ctrl'}+L)`
+  leftDom.onclick = function() {
+    console.log('left')
+    instance.command.executeRowFlex(RowFlex.LEFT)
+  }
+
+  const centerDom =
+    document.querySelector<HTMLDivElement>('.menu-item__center')!
+  centerDom.title = `居中对齐(${isApple ? '⌘' : 'Ctrl'}+E)`
+  centerDom.onclick = function() {
+    console.log('center')
+    instance.command.executeRowFlex(RowFlex.CENTER)
+  }
+
+  const rightDom = document.querySelector<HTMLDivElement>('.menu-item__right')!
+  rightDom.title = `右对齐(${isApple ? '⌘' : 'Ctrl'}+R)`
+  rightDom.onclick = function() {
+    console.log('right')
+    instance.command.executeRowFlex(RowFlex.RIGHT)
+  }
+
+  const alignmentDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__alignment'
+  )!
+  alignmentDom.title = `两端对齐(${isApple ? '⌘' : 'Ctrl'}+J)`
+  alignmentDom.onclick = function() {
+    console.log('alignment')
+    instance.command.executeRowFlex(RowFlex.ALIGNMENT)
+  }
+
+  const justifyDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__justify'
+  )!
+  justifyDom.title = `分散对齐(${isApple ? '⌘' : 'Ctrl'}+Shift+J)`
+  justifyDom.onclick = function() {
+    console.log('justify')
+    instance.command.executeRowFlex(RowFlex.JUSTIFY)
+  }
+
+  const rowMarginDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__row-margin'
+  )!
+  const rowOptionDom = rowMarginDom.querySelector<HTMLDivElement>('.options')!
+  rowMarginDom.onclick = function() {
+    console.log('row-margin')
+    rowOptionDom.classList.toggle('visible')
+  }
+  rowOptionDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    instance.command.executeRowMargin(Number(li.dataset.rowmargin!))
+  }
+
+  const listDom = document.querySelector<HTMLDivElement>('.menu-item__list')!
+  listDom.title = `列表(${isApple ? '⌘' : 'Ctrl'}+Shift+U)`
+  const listOptionDom = listDom.querySelector<HTMLDivElement>('.options')!
+  listDom.onclick = function() {
+    console.log('list')
+    listOptionDom.classList.toggle('visible')
+  }
+  listOptionDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const listType = <ListType>li.dataset.listType || null
+    const listStyle = <ListStyle>(<unknown>li.dataset.listStyle)
+    instance.command.executeList(listType, listStyle)
+  }
+
+  // 4. | 表格 | 图片 | 超链接 | 分割线 | 水印 | 代码块 | 分隔符 | 控件 | 复选框 | LaTeX | 日期选择器
+  const tableDom = document.querySelector<HTMLDivElement>('.menu-item__table')!
+  const tablePanelContainer = document.querySelector<HTMLDivElement>(
+    '.menu-item__table__collapse'
+  )!
+  const tableClose = document.querySelector<HTMLDivElement>('.table-close')!
+  const tableTitle = document.querySelector<HTMLDivElement>('.table-select')!
+  const tablePanel = document.querySelector<HTMLDivElement>('.table-panel')!
+  // 绘制行列
+  const tableCellList: HTMLDivElement[][] = []
+  for (let i = 0; i < 10; i++) {
+    const tr = document.createElement('tr')
+    tr.classList.add('table-row')
+    const trCellList: HTMLDivElement[] = []
+    for (let j = 0; j < 10; j++) {
+      const td = document.createElement('td')
+      td.classList.add('table-cel')
+      tr.append(td)
+      trCellList.push(td)
+    }
+    tablePanel.append(tr)
+    tableCellList.push(trCellList)
+  }
+  let colIndex = 0
+  let rowIndex = 0
+
+  // 移除所有格选择
+  function removeAllTableCellSelect() {
+    tableCellList.forEach(tr => {
+      tr.forEach(td => td.classList.remove('active'))
+    })
+  }
+
+  // 设置标题内容
+  function setTableTitle(payload: string) {
+    tableTitle.innerText = payload
+  }
+
+  // 恢复初始状态
+  function recoveryTable() {
+    // 还原选择样式、标题、选择行列
+    removeAllTableCellSelect()
+    setTableTitle('插入')
+    colIndex = 0
+    rowIndex = 0
+    // 隐藏panel
+    tablePanelContainer.style.display = 'none'
+  }
+
+  tableDom.onclick = function() {
+    console.log('table')
+    tablePanelContainer!.style.display = 'block'
+  }
+  tablePanel.onmousemove = function(evt) {
+    const celSize = 16
+    const rowMarginTop = 10
+    const celMarginRight = 6
+    const { offsetX, offsetY } = evt
+    // 移除所有选择
+    removeAllTableCellSelect()
+    colIndex = Math.ceil(offsetX / (celSize + celMarginRight)) || 1
+    rowIndex = Math.ceil(offsetY / (celSize + rowMarginTop)) || 1
+    // 改变选择样式
+    tableCellList.forEach((tr, trIndex) => {
+      tr.forEach((td, tdIndex) => {
+        if (tdIndex < colIndex && trIndex < rowIndex) {
+          td.classList.add('active')
+        }
+      })
+    })
+    // 改变表格标题
+    setTableTitle(`${rowIndex}×${colIndex}`)
+  }
+  tableClose.onclick = function() {
+    recoveryTable()
+  }
+  tablePanel.onclick = function() {
+    // 应用选择
+    instance.command.executeInsertTable(rowIndex, colIndex)
+    recoveryTable()
+  }
+
+  const imageDom = document.querySelector<HTMLDivElement>('.menu-item__image')!
+  const imageFileDom = document.querySelector<HTMLInputElement>('#image')!
+  imageDom.onclick = function() {
+    imageFileDom.click()
+  }
+  imageFileDom.onchange = function() {
+    const file = imageFileDom.files![0]!
+    const fileReader = new FileReader()
+    fileReader.readAsDataURL(file)
+    fileReader.onload = function() {
+      // 计算宽高
+      const image = new Image()
+      const value = fileReader.result as string
+      image.src = value
+      image.onload = function() {
+        instance.command.executeImage({
+          value,
+          width: image.width,
+          height: image.height
+        })
+        imageFileDom.value = ''
+      }
+    }
+  }
+
+  const hyperlinkDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__hyperlink'
+  )!
+  hyperlinkDom.onclick = function() {
+    console.log('hyperlink')
+    new Dialog({
+      title: '超链接',
+      data: [
+        {
+          type: 'text',
+          label: '文本',
+          name: 'name',
+          required: true,
+          placeholder: '请输入文本',
+          value: instance.command.getRangeText()
+        },
+        {
+          type: 'text',
+          label: '链接',
+          name: 'url',
+          required: true,
+          placeholder: '请输入链接'
+        }
+      ],
+      onConfirm: payload => {
+        const name = payload.find(p => p.name === 'name')?.value
+        if (!name) return
+        const url = payload.find(p => p.name === 'url')?.value
+        if (!url) return
+        instance.command.executeHyperlink({
+          type: ElementType.HYPERLINK,
+          value: '',
+          url,
+          valueList: splitText(name).map(n => ({
+            value: n,
+            size: 16
+          }))
+        })
+      }
+    })
+  }
+
+  const separatorDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__separator'
+  )!
+  const separatorOptionDom =
+    separatorDom.querySelector<HTMLDivElement>('.options')!
+  separatorDom.onclick = function() {
+    console.log('separator')
+    separatorOptionDom.classList.toggle('visible')
+  }
+  separatorOptionDom.onmousedown = function(evt) {
+    let payload: number[] = []
+    const li = evt.target as HTMLLIElement
+    const separatorDash = li.dataset.separator?.split(',').map(Number)
+    if (separatorDash) {
+      const isSingleLine = separatorDash.every(d => d === 0)
+      if (!isSingleLine) {
+        payload = separatorDash
+      }
+    }
+    instance.command.executeSeparator(payload)
+  }
+
+  const pageBreakDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__page-break'
+  )!
+  pageBreakDom.onclick = function() {
+    console.log('pageBreak')
+    instance.command.executePageBreak()
+  }
+
+  const watermarkDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__watermark'
+  )!
+  const watermarkOptionDom =
+    watermarkDom.querySelector<HTMLDivElement>('.options')!
+  watermarkDom.onclick = function() {
+    console.log('watermark')
+    watermarkOptionDom.classList.toggle('visible')
+  }
+  watermarkOptionDom.onmousedown = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const menu = li.dataset.menu!
+    watermarkOptionDom.classList.toggle('visible')
+    if (menu === 'add') {
+      new Dialog({
+        title: '水印',
+        data: [
+          {
+            type: 'text',
+            label: '内容',
+            name: 'data',
+            required: true,
+            placeholder: '请输入内容'
+          },
+          {
+            type: 'color',
+            label: '颜色',
+            name: 'color',
+            required: true,
+            value: '#AEB5C0'
+          },
+          {
+            type: 'number',
+            label: '字体大小',
+            name: 'size',
+            required: true,
+            value: '120'
+          },
+          {
+            type: 'number',
+            label: '透明度',
+            name: 'opacity',
+            required: true,
+            value: '0.3'
+          },
+          {
+            type: 'select',
+            label: '重复',
+            name: 'repeat',
+            value: '0',
+            required: false,
+            options: [
+              {
+                label: '不重复',
+                value: '0'
+              },
+              {
+                label: '重复',
+                value: '1'
+              }
+            ]
+          },
+          {
+            type: 'number',
+            label: '水平间隔',
+            name: 'horizontalGap',
+            required: false,
+            value: '10'
+          },
+          {
+            type: 'number',
+            label: '垂直间隔',
+            name: 'verticalGap',
+            required: false,
+            value: '10'
+          }
+        ],
+        onConfirm: payload => {
+          const nullableIndex = payload.findIndex(p => !p.value)
+          if (~nullableIndex) return
+          const watermark = payload.reduce((pre, cur) => {
+            pre[cur.name] = cur.value
+            return pre
+          }, <any>{})
+          const repeat = watermark.repeat === '1'
+          instance.command.executeAddWatermark({
+            data: watermark.data,
+            color: watermark.color,
+            size: Number(watermark.size),
+            opacity: Number(watermark.opacity),
+            repeat,
+            gap:
+              repeat && watermark.horizontalGap && watermark.verticalGap
+                ? [
+                  Number(watermark.horizontalGap),
+                  Number(watermark.verticalGap)
+                ]
+                : undefined
+          })
+        }
+      })
+    } else {
+      instance.command.executeDeleteWatermark()
+    }
+  }
+
+  const codeblockDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__codeblock'
+  )!
+  codeblockDom.onclick = function() {
+    console.log('codeblock')
+    new Dialog({
+      title: '代码块',
+      data: [
+        {
+          type: 'textarea',
+          name: 'codeblock',
+          placeholder: '请输入代码',
+          width: 500,
+          height: 300
+        }
+      ],
+      onConfirm: payload => {
+        const codeblock = payload.find(p => p.name === 'codeblock')?.value
+        if (!codeblock) return
+        const tokenList = prism.tokenize(codeblock, prism.languages.javascript)
+        const formatTokenList = formatPrismToken(tokenList)
+        const elementList: IElement[] = []
+        for (let i = 0; i < formatTokenList.length; i++) {
+          const formatToken = formatTokenList[i]
+          const tokenStringList = splitText(formatToken.content)
+          for (let j = 0; j < tokenStringList.length; j++) {
+            const value = tokenStringList[j]
+            const element: IElement = {
+              value
+            }
+            if (formatToken.color) {
+              element.color = formatToken.color
+            }
+            if (formatToken.bold) {
+              element.bold = true
+            }
+            if (formatToken.italic) {
+              element.italic = true
+            }
+            elementList.push(element)
+          }
+        }
+        elementList.unshift({
+          value: '\n'
+        })
+        instance.command.executeInsertElementList(elementList)
+      }
+    })
+  }
+
+  const controlDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__control'
+  )!
+  const controlOptionDom = controlDom.querySelector<HTMLDivElement>('.options')!
+  controlDom.onclick = function() {
+    console.log('control')
+    controlOptionDom.classList.toggle('visible')
+  }
+  controlOptionDom.onmousedown = function(evt) {
+    controlOptionDom.classList.toggle('visible')
+    const li = evt.target as HTMLLIElement
+    const type = <ControlType>li.dataset.control
+    switch (type) {
+      case ControlType.TEXT:
+        new Dialog({
+          title: '文本控件',
+          data: [
+            {
+              type: 'text',
+              label: '占位符',
+              name: 'placeholder',
+              required: true,
+              placeholder: '请输入占位符'
+            },
+            {
+              type: 'text',
+              label: '默认值',
+              name: 'value',
+              placeholder: '请输入默认值'
+            }
+          ],
+          onConfirm: payload => {
+            const placeholder = payload.find(
+              p => p.name === 'placeholder'
+            )?.value
+            if (!placeholder) return
+            const value = payload.find(p => p.name === 'value')?.value || ''
+            instance.command.executeInsertControl({
+              type: ElementType.CONTROL,
+              value: '',
+              control: {
+                type,
+                value: value
+                  ? [
+                    {
+                      value
+                    }
+                  ]
+                  : null,
+                placeholder
+              }
+            })
+          }
+        })
+        break
+      case ControlType.SELECT:
+        new Dialog({
+          title: '列举控件',
+          data: [
+            {
+              type: 'text',
+              label: '占位符',
+              name: 'placeholder',
+              required: true,
+              placeholder: '请输入占位符'
+            },
+            {
+              type: 'text',
+              label: '默认值',
+              name: 'code',
+              placeholder: '请输入默认值'
+            },
+            {
+              type: 'textarea',
+              label: '值集',
+              name: 'valueSets',
+              required: true,
+              height: 100,
+              placeholder: `请输入值集JSON，例：\n[{\n"value":"有",\n"code":"98175"\n}]`
+            }
+          ],
+          onConfirm: payload => {
+            const placeholder = payload.find(
+              p => p.name === 'placeholder'
+            )?.value
+            if (!placeholder) return
+            const valueSets = payload.find(p => p.name === 'valueSets')?.value
+            if (!valueSets) return
+            const code = payload.find(p => p.name === 'code')?.value
+            instance.command.executeInsertControl({
+              type: ElementType.CONTROL,
+              value: '',
+              control: {
+                type,
+                code,
+                value: null,
+                placeholder,
+                valueSets: JSON.parse(valueSets)
+              }
+            })
+          }
+        })
+        break
+      case ControlType.CHECKBOX:
+        new Dialog({
+          title: '复选框控件',
+          data: [
+            {
+              type: 'text',
+              label: '默认值',
+              name: 'code',
+              placeholder: '请输入默认值，多个值以英文逗号分割'
+            },
+            {
+              type: 'textarea',
+              label: '值集',
+              name: 'valueSets',
+              required: true,
+              height: 100,
+              placeholder: `请输入值集JSON，例：\n[{\n"value":"有",\n"code":"98175"\n}]`
+            }
+          ],
+          onConfirm: payload => {
+            const valueSets = payload.find(p => p.name === 'valueSets')?.value
+            if (!valueSets) return
+            const code = payload.find(p => p.name === 'code')?.value
+            instance.command.executeInsertControl({
+              type: ElementType.CONTROL,
+              value: '',
+              control: {
+                type,
+                code,
+                value: null,
+                valueSets: JSON.parse(valueSets)
+              }
+            })
+          }
+        })
+        break
+      case ControlType.RADIO:
+        new Dialog({
+          title: '单选框控件',
+          data: [
+            {
+              type: 'text',
+              label: '默认值',
+              name: 'code',
+              placeholder: '请输入默认值'
+            },
+            {
+              type: 'textarea',
+              label: '值集',
+              name: 'valueSets',
+              required: true,
+              height: 100,
+              placeholder: `请输入值集JSON，例：\n[{\n"value":"有",\n"code":"98175"\n}]`
+            }
+          ],
+          onConfirm: payload => {
+            const valueSets = payload.find(p => p.name === 'valueSets')?.value
+            if (!valueSets) return
+            const code = payload.find(p => p.name === 'code')?.value
+            instance.command.executeInsertControl({
+              type: ElementType.CONTROL,
+              value: '',
+              control: {
+                type,
+                code,
+                value: null,
+                valueSets: JSON.parse(valueSets)
+              }
+            })
+          }
+        })
+        break
+      case ControlType.DATE:
+        new Dialog({
+          title: '日期控件',
+          data: [
+            {
+              type: 'text',
+              label: '占位符',
+              name: 'placeholder',
+              required: true,
+              placeholder: '请输入占位符'
+            },
+            {
+              type: 'text',
+              label: '默认值',
+              name: 'value',
+              placeholder: '请输入默认值'
+            },
+            {
+              type: 'select',
+              label: '日期格式',
+              name: 'dateFormat',
+              value: 'yyyy-MM-dd hh:mm:ss',
+              required: true,
+              options: [
+                {
+                  label: 'yyyy-MM-dd hh:mm:ss',
+                  value: 'yyyy-MM-dd hh:mm:ss'
+                },
+                {
+                  label: 'yyyy-MM-dd',
+                  value: 'yyyy-MM-dd'
+                }
+              ]
+            }
+          ],
+          onConfirm: payload => {
+            const placeholder = payload.find(
+              p => p.name === 'placeholder'
+            )?.value
+            if (!placeholder) return
+            const value = payload.find(p => p.name === 'value')?.value || ''
+            const dateFormat =
+              payload.find(p => p.name === 'dateFormat')?.value || ''
+            instance.command.executeInsertControl({
+              type: ElementType.CONTROL,
+              value: '',
+              control: {
+                type,
+                dateFormat,
+                value: value
+                  ? [
+                    {
+                      value
+                    }
+                  ]
+                  : null,
+                placeholder
+              }
+            })
+          }
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  const checkboxDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__checkbox'
+  )!
+  checkboxDom.onclick = function() {
+    console.log('checkbox')
+    instance.command.executeInsertElementList([
+      {
+        type: ElementType.CHECKBOX,
+        checkbox: {
+          value: false
+        },
+        value: ''
+      }
+    ])
+  }
+
+  const radioDom = document.querySelector<HTMLDivElement>('.menu-item__radio')!
+  radioDom.onclick = function() {
+    console.log('radio')
+    instance.command.executeInsertElementList([
+      {
+        type: ElementType.RADIO,
+        checkbox: {
+          value: false
+        },
+        value: ''
+      }
+    ])
+  }
+
+  const latexDom = document.querySelector<HTMLDivElement>('.menu-item__latex')!
+  latexDom.onclick = function() {
+    console.log('LaTeX')
+    new Dialog({
+      title: 'LaTeX',
+      data: [
+        {
+          type: 'textarea',
+          height: 100,
+          name: 'value',
+          placeholder: '请输入LaTeX文本'
+        }
+      ],
+      onConfirm: payload => {
+        const value = payload.find(p => p.name === 'value')?.value
+        if (!value) return
+        instance.command.executeInsertElementList([
+          {
+            type: ElementType.LATEX,
+            value
+          }
+        ])
+      }
+    })
+  }
+
+  const dateDom = document.querySelector<HTMLDivElement>('.menu-item__date')!
+  const dateDomOptionDom = dateDom.querySelector<HTMLDivElement>('.options')!
+  dateDom.onclick = function() {
+    console.log('date')
+    dateDomOptionDom.classList.toggle('visible')
+    // 定位调整
+    const bodyRect = document.body.getBoundingClientRect()
+    const dateDomOptionRect = dateDomOptionDom.getBoundingClientRect()
+    if (dateDomOptionRect.left + dateDomOptionRect.width > bodyRect.width) {
+      dateDomOptionDom.style.right = '0px'
+      dateDomOptionDom.style.left = 'unset'
+    } else {
+      dateDomOptionDom.style.right = 'unset'
+      dateDomOptionDom.style.left = '0px'
+    }
+    // 当前日期
+    const date = new Date()
+    const year = date.getFullYear().toString()
+    const month = (date.getMonth() + 1).toString().padStart(2, '0')
+    const day = date.getDate().toString().padStart(2, '0')
+    const hour = date.getHours().toString().padStart(2, '0')
+    const minute = date.getMinutes().toString().padStart(2, '0')
+    const second = date.getSeconds().toString().padStart(2, '0')
+    const dateString = `${year}-${month}-${day}`
+    const dateTimeString = `${dateString} ${hour}:${minute}:${second}`
+    dateDomOptionDom.querySelector<HTMLLIElement>('li:first-child')!.innerText =
+      dateString
+    dateDomOptionDom.querySelector<HTMLLIElement>('li:last-child')!.innerText =
+      dateTimeString
+  }
+  dateDomOptionDom.onmousedown = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const dateFormat = li.dataset.format!
+    dateDomOptionDom.classList.toggle('visible')
+    instance.command.executeInsertElementList([
+      {
+        type: ElementType.DATE,
+        value: '',
+        dateFormat,
+        valueList: [
+          {
+            value: li.innerText.trim()
+          }
+        ]
+      }
+    ])
+  }
+
+  const blockDom = document.querySelector<HTMLDivElement>('.menu-item__block')!
+  blockDom.onclick = function() {
+    console.log('block')
+    new Dialog({
+      title: '内容块',
+      data: [
+        {
+          type: 'select',
+          label: '类型',
+          name: 'type',
+          value: 'iframe',
+          required: true,
+          options: [
+            {
+              label: '网址',
+              value: 'iframe'
+            },
+            {
+              label: '视频',
+              value: 'video'
+            }
+          ]
+        },
+        {
+          type: 'number',
+          label: '宽度',
+          name: 'width',
+          placeholder: '请输入宽度（默认页面内宽度）'
+        },
+        {
+          type: 'number',
+          label: '高度',
+          name: 'height',
+          required: true,
+          placeholder: '请输入高度'
+        },
+        {
+          type: 'input',
+          label: '地址',
+          name: 'src',
+          required: false,
+          placeholder: '请输入地址'
+        },
+        {
+          type: 'textarea',
+          label: 'HTML',
+          height: 100,
+          name: 'srcdoc',
+          required: false,
+          placeholder: '请输入HTML代码（仅网址类型有效）'
+        }
+      ],
+      onConfirm: payload => {
+        const type = payload.find(p => p.name === 'type')?.value
+        if (!type) return
+        const width = payload.find(p => p.name === 'width')?.value
+        const height = payload.find(p => p.name === 'height')?.value
+        if (!height) return
+        // 地址或HTML代码至少存在一项
+        const src = payload.find(p => p.name === 'src')?.value
+        const srcdoc = payload.find(p => p.name === 'srcdoc')?.value
+        const block: IBlock = {
+          type: <BlockType>type
+        }
+        if (block.type === BlockType.IFRAME) {
+          if (!src && !srcdoc) return
+          block.iframeBlock = {
+            src,
+            srcdoc
+          }
+        } else if (block.type === BlockType.VIDEO) {
+          if (!src) return
+          block.videoBlock = {
+            src
+          }
+        }
+        const blockElement: IElement = {
+          type: ElementType.BLOCK,
+          value: '',
+          height: Number(height),
+          block
+        }
+        if (width) {
+          blockElement.width = Number(width)
+        }
+        instance.command.executeInsertElementList([blockElement])
+      }
+    })
+  }
+
+  // 5. | 搜索&替换 | 打印 |
+  const searchCollapseDom = document.querySelector<HTMLDivElement>(
+    '.menu-item__search__collapse'
+  )!
+  const searchInputDom = document.querySelector<HTMLInputElement>(
+    '.menu-item__search__collapse__search input'
+  )!
+  const replaceInputDom = document.querySelector<HTMLInputElement>(
+    '.menu-item__search__collapse__replace input'
+  )!
+  const searchDom =
+    document.querySelector<HTMLDivElement>('.menu-item__search')!
+  searchDom.title = `搜索与替换(${isApple ? '⌘' : 'Ctrl'}+F)`
+  const searchResultDom =
+    searchCollapseDom.querySelector<HTMLLabelElement>('.search-result')!
+
+  function setSearchResult() {
+    const result = instance.command.getSearchNavigateInfo()
+    if (result) {
+      const { index, count } = result
+      searchResultDom.innerText = `${index}/${count}`
+    } else {
+      searchResultDom.innerText = ''
+    }
+  }
+
+  searchDom.onclick = function() {
+    console.log('search')
+    searchCollapseDom.style.display = 'block'
+    const bodyRect = document.body.getBoundingClientRect()
+    const searchRect = searchDom.getBoundingClientRect()
+    const searchCollapseRect = searchCollapseDom.getBoundingClientRect()
+    if (searchRect.left + searchCollapseRect.width > bodyRect.width) {
+      searchCollapseDom.style.right = '0px'
+      searchCollapseDom.style.left = 'unset'
+    } else {
+      searchCollapseDom.style.right = 'unset'
+    }
+    searchInputDom.focus()
+  }
+  searchCollapseDom.querySelector<HTMLSpanElement>('span')!.onclick =
+    function() {
+      searchCollapseDom.style.display = 'none'
+      searchInputDom.value = ''
+      replaceInputDom.value = ''
+      instance.command.executeSearch(null)
+      setSearchResult()
+    }
+  searchInputDom.oninput = function() {
+    instance.command.executeSearch(searchInputDom.value || null)
+    setSearchResult()
+  }
+  searchInputDom.onkeydown = function(evt) {
+    if (evt.key === 'Enter') {
+      instance.command.executeSearch(searchInputDom.value || null)
+      setSearchResult()
+    }
+  }
+  searchCollapseDom.querySelector<HTMLButtonElement>('button')!.onclick =
+    function() {
+      const searchValue = searchInputDom.value
+      const replaceValue = replaceInputDom.value
+      if (searchValue && replaceValue && searchValue !== replaceValue) {
+        instance.command.executeReplace(replaceValue)
+      }
+    }
+  searchCollapseDom.querySelector<HTMLDivElement>('.arrow-left')!.onclick =
+    function() {
+      instance.command.executeSearchNavigatePre()
+      setSearchResult()
+    }
+  searchCollapseDom.querySelector<HTMLDivElement>('.arrow-right')!.onclick =
+    function() {
+      instance.command.executeSearchNavigateNext()
+      setSearchResult()
+    }
+
+  const printDom = document.querySelector<HTMLDivElement>('.menu-item__print')!
+  printDom.title = `打印(${isApple ? '⌘' : 'Ctrl'}+P)`
+  printDom.onclick = function() {
+    console.log('print')
+    instance.command.executePrint()
+  }
+
+  // 6. 目录显隐 | 页面模式 | 纸张缩放 | 纸张大小 | 纸张方向 | 页边距 | 全屏 | 设置
+  const editorOptionDom =
+    document.querySelector<HTMLDivElement>('.editor-option')!
+  editorOptionDom.onclick = function() {
+    const options = instance.command.getOptions()
+    new Dialog({
+      title: '编辑器配置',
+      data: [
+        {
+          type: 'textarea',
+          name: 'option',
+          width: 350,
+          height: 300,
+          required: true,
+          value: JSON.stringify(options, null, 2),
+          placeholder: '请输入编辑器配置'
+        }
+      ],
+      onConfirm: payload => {
+        const newOptionValue = payload.find(p => p.name === 'option')?.value
+        if (!newOptionValue) return
+        const newOption = JSON.parse(newOptionValue)
+        instance.command.executeUpdateOptions(newOption)
+      }
+    })
+  }
+
+  const pageModeDom = document.querySelector<HTMLDivElement>('.page-mode')!
+  const pageModeOptionsDom =
+    pageModeDom.querySelector<HTMLDivElement>('.options')!
+  pageModeDom.onclick = function() {
+    pageModeOptionsDom.classList.toggle('visible')
+  }
+  pageModeOptionsDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    instance.command.executePageMode(<PageMode>li.dataset.pageMode!)
+  }
+
+  document.querySelector<HTMLDivElement>('.page-scale-percentage')!.onclick =
+    function() {
+      console.log('page-scale-recovery')
+      instance.command.executePageScaleRecovery()
+    }
+
+  document.querySelector<HTMLDivElement>('.page-scale-minus')!.onclick =
+    function() {
+      console.log('page-scale-minus')
+      instance.command.executePageScaleMinus()
+    }
+
+  document.querySelector<HTMLDivElement>('.page-scale-add')!.onclick =
+    function() {
+      console.log('page-scale-add')
+      instance.command.executePageScaleAdd()
+    }
+
+  // 纸张大小
+  const paperSizeDom = document.querySelector<HTMLDivElement>('.paper-size')!
+  const paperSizeDomOptionsDom =
+    paperSizeDom.querySelector<HTMLDivElement>('.options')!
+  paperSizeDom.onclick = function() {
+    paperSizeDomOptionsDom.classList.toggle('visible')
+  }
+  paperSizeDomOptionsDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const paperType = li.dataset.paperSize!
+    const [width, height] = paperType.split('*').map(Number)
+    instance.command.executePaperSize(width, height)
+    // 纸张状态回显
+    paperSizeDomOptionsDom
+      .querySelectorAll('li')
+      .forEach(child => child.classList.remove('active'))
+    li.classList.add('active')
+  }
+
+  // 纸张方向
+  const paperDirectionDom =
+    document.querySelector<HTMLDivElement>('.paper-direction')!
+  const paperDirectionDomOptionsDom =
+    paperDirectionDom.querySelector<HTMLDivElement>('.options')!
+  paperDirectionDom.onclick = function() {
+    paperDirectionDomOptionsDom.classList.toggle('visible')
+  }
+  paperDirectionDomOptionsDom.onclick = function(evt) {
+    const li = evt.target as HTMLLIElement
+    const paperDirection = li.dataset.paperDirection!
+    instance.command.executePaperDirection(<PaperDirection>paperDirection)
+    // 纸张方向状态回显
+    paperDirectionDomOptionsDom
+      .querySelectorAll('li')
+      .forEach(child => child.classList.remove('active'))
+    li.classList.add('active')
+  }
+
+  // 页面边距
+  const paperMarginDom =
+    document.querySelector<HTMLDivElement>('.paper-margin')!
+  paperMarginDom.onclick = function() {
+    const [topMargin, rightMargin, bottomMargin, leftMargin] =
+      instance.command.getPaperMargin()
+    new Dialog({
+      title: '页边距',
+      data: [
+        {
+          type: 'text',
+          label: '上边距',
+          name: 'top',
+          required: true,
+          value: `${topMargin}`,
+          placeholder: '请输入上边距'
+        },
+        {
+          type: 'text',
+          label: '下边距',
+          name: 'bottom',
+          required: true,
+          value: `${bottomMargin}`,
+          placeholder: '请输入下边距'
+        },
+        {
+          type: 'text',
+          label: '左边距',
+          name: 'left',
+          required: true,
+          value: `${leftMargin}`,
+          placeholder: '请输入左边距'
+        },
+        {
+          type: 'text',
+          label: '右边距',
+          name: 'right',
+          required: true,
+          value: `${rightMargin}`,
+          placeholder: '请输入右边距'
+        }
+      ],
+      onConfirm: payload => {
+        const top = payload.find(p => p.name === 'top')?.value
+        if (!top) return
+        const bottom = payload.find(p => p.name === 'bottom')?.value
+        if (!bottom) return
+        const left = payload.find(p => p.name === 'left')?.value
+        if (!left) return
+        const right = payload.find(p => p.name === 'right')?.value
+        if (!right) return
+        instance.command.executeSetPaperMargin([
+          Number(top),
+          Number(right),
+          Number(bottom),
+          Number(left)
+        ])
+      }
+    })
+  }
+
+  // 全屏
+  const fullscreenDom = document.querySelector<HTMLDivElement>('.fullscreen')!
+  fullscreenDom.onclick = toggleFullscreen
+  window.addEventListener('keydown', evt => {
+    if (evt.key === 'F11') {
+      toggleFullscreen()
+      evt.preventDefault()
+    }
+  })
+  document.addEventListener('fullscreenchange', () => {
+    fullscreenDom.classList.toggle('exist')
+  })
+
+  function toggleFullscreen() {
+    console.log('fullscreen')
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen()
+    } else {
+      document.exitFullscreen()
+    }
+  }
+
+  // 7. 编辑器使用模式
+  let modeIndex = 0
+  const modeList = [
+    {
+      mode: EditorMode.EDIT,
+      name: '编辑模式'
+    },
+    {
+      mode: EditorMode.CLEAN,
+      name: '清洁模式'
+    },
+    {
+      mode: EditorMode.READONLY,
+      name: '只读模式'
+    },
+    {
+      mode: EditorMode.FORM,
+      name: '表单模式'
+    },
+    {
+      mode: EditorMode.PRINT,
+      name: '打印模式'
+    },
+    {
+      mode: EditorMode.DESIGN,
+      name: '设计模式'
+    }
+  ]
+  const modeElement = document.querySelector<HTMLDivElement>('.editor-mode')!
+  modeElement.onclick = function() {
+    // 模式选择循环
+    modeIndex === modeList.length - 1 ? (modeIndex = 0) : modeIndex++
+    // 设置模式
+    const { name, mode } = modeList[modeIndex]
+    modeElement.innerText = name
+    instance.command.executeMode(mode)
+    // 设置菜单栏权限视觉反馈
+    const isReadonly = mode === EditorMode.READONLY
+    const enableMenuList = ['search', 'print']
+    document.querySelectorAll<HTMLDivElement>('.menu-item>div').forEach(dom => {
+      const menu = dom.dataset.menu
+      isReadonly && (!menu || !enableMenuList.includes(menu))
+        ? dom.classList.add('disable')
+        : dom.classList.remove('disable')
+    })
+  }
+
+  // 8. 内部事件监听
+  instance.listener.rangeStyleChange = function(payload) {
+    // 控件类型
+    payload.type === ElementType.SUBSCRIPT
+      ? subscriptDom.classList.add('active')
+      : subscriptDom.classList.remove('active')
+    payload.type === ElementType.SUPERSCRIPT
+      ? superscriptDom.classList.add('active')
+      : superscriptDom.classList.remove('active')
+    payload.type === ElementType.SEPARATOR
+      ? separatorDom.classList.add('active')
+      : separatorDom.classList.remove('active')
+    separatorOptionDom
+      .querySelectorAll('li')
+      .forEach(li => li.classList.remove('active'))
+    if (payload.type === ElementType.SEPARATOR) {
+      const separator = payload.dashArray.join(',') || '0,0'
+      const curSeparatorDom = separatorOptionDom.querySelector<HTMLLIElement>(
+        `[data-separator='${separator}']`
+      )!
+      if (curSeparatorDom) {
+        curSeparatorDom.classList.add('active')
+      }
+    }
+
+    // 富文本
+    fontOptionDom
+      .querySelectorAll<HTMLLIElement>('li')
+      .forEach(li => li.classList.remove('active'))
+    const curFontDom = fontOptionDom.querySelector<HTMLLIElement>(
+      `[data-family='${payload.font}']`
+    )
+    if (curFontDom) {
+      fontSelectDom.innerText = curFontDom.innerText
+      fontSelectDom.style.fontFamily = payload.font
+      curFontDom.classList.add('active')
+    }
+    sizeOptionDom
+      .querySelectorAll<HTMLLIElement>('li')
+      .forEach(li => li.classList.remove('active'))
+    const curSizeDom = sizeOptionDom.querySelector<HTMLLIElement>(
+      `[data-size='${payload.size}']`
+    )
+    if (curSizeDom) {
+      sizeSelectDom.innerText = curSizeDom.innerText
+      curSizeDom.classList.add('active')
+    } else {
+      sizeSelectDom.innerText = `${payload.size}`
+    }
+    payload.bold
+      ? boldDom.classList.add('active')
+      : boldDom.classList.remove('active')
+    payload.italic
+      ? italicDom.classList.add('active')
+      : italicDom.classList.remove('active')
+    payload.underline
+      ? underlineDom.classList.add('active')
+      : underlineDom.classList.remove('active')
+    payload.strikeout
+      ? strikeoutDom.classList.add('active')
+      : strikeoutDom.classList.remove('active')
+    if (payload.color) {
+      colorDom.classList.add('active')
+      colorControlDom.value = payload.color
+      colorSpanDom.style.backgroundColor = payload.color
+    } else {
+      colorDom.classList.remove('active')
+      colorControlDom.value = '#000000'
+      colorSpanDom.style.backgroundColor = '#000000'
+    }
+    if (payload.highlight) {
+      highlightDom.classList.add('active')
+      highlightControlDom.value = payload.highlight
+      highlightSpanDom.style.backgroundColor = payload.highlight
+    } else {
+      highlightDom.classList.remove('active')
+      highlightControlDom.value = '#ffff00'
+      highlightSpanDom.style.backgroundColor = '#ffff00'
+    }
+
+    // 行布局
+    leftDom.classList.remove('active')
+    centerDom.classList.remove('active')
+    rightDom.classList.remove('active')
+    alignmentDom.classList.remove('active')
+    justifyDom.classList.remove('active')
+    if (payload.rowFlex && payload.rowFlex === 'right') {
+      rightDom.classList.add('active')
+    } else if (payload.rowFlex && payload.rowFlex === 'center') {
+      centerDom.classList.add('active')
+    } else if (payload.rowFlex && payload.rowFlex === 'alignment') {
+      alignmentDom.classList.add('active')
+    } else if (payload.rowFlex && payload.rowFlex === 'justify') {
+      justifyDom.classList.add('active')
+    } else {
+      leftDom.classList.add('active')
+    }
+
+    // 行间距
+    rowOptionDom
+      .querySelectorAll<HTMLLIElement>('li')
+      .forEach(li => li.classList.remove('active'))
+    const curRowMarginDom = rowOptionDom.querySelector<HTMLLIElement>(
+      `[data-rowmargin='${payload.rowMargin}']`
+    )!
+    curRowMarginDom.classList.add('active')
+
+    // 功能
+    payload.undo
+      ? undoDom.classList.remove('no-allow')
+      : undoDom.classList.add('no-allow')
+    payload.redo
+      ? redoDom.classList.remove('no-allow')
+      : redoDom.classList.add('no-allow')
+    payload.painter
+      ? painterDom.classList.add('active')
+      : painterDom.classList.remove('active')
+
+    // 标题
+    titleOptionDom
+      .querySelectorAll<HTMLLIElement>('li')
+      .forEach(li => li.classList.remove('active'))
+    if (payload.level) {
+      const curTitleDom = titleOptionDom.querySelector<HTMLLIElement>(
+        `[data-level='${payload.level}']`
+      )!
+      titleSelectDom.innerText = curTitleDom.innerText
+      curTitleDom.classList.add('active')
+    } else {
+      titleSelectDom.innerText = '正文'
+      titleOptionDom.querySelector('li:first-child')!.classList.add('active')
+    }
+
+    // 列表
+    listOptionDom
+      .querySelectorAll<HTMLLIElement>('li')
+      .forEach(li => li.classList.remove('active'))
+    if (payload.listType) {
+      listDom.classList.add('active')
+      const listType = payload.listType
+      const listStyle =
+        payload.listType === ListType.OL ? ListStyle.DECIMAL : payload.listType
+      const curListDom = listOptionDom.querySelector<HTMLLIElement>(
+        `[data-list-type='${listType}'][data-list-style='${listStyle}']`
+      )
+      if (curListDom) {
+        curListDom.classList.add('active')
+      }
+    } else {
+      listDom.classList.remove('active')
+    }
+  }
+  instance.listener.visiblePageNoListChange = function(payload) {
+    const text = payload.map(i => i + 1).join('、')
+    document.querySelector<HTMLSpanElement>('.page-no-list')!.innerText = text
+  }
+
+  instance.listener.pageSizeChange = function(payload) {
+    document.querySelector<HTMLSpanElement>(
+      '.page-size'
+    )!.innerText = `${payload}`
+  }
+
+  instance.listener.intersectionPageNoChange = function(payload) {
+    document.querySelector<HTMLSpanElement>('.page-no')!.innerText = `${
+      payload + 1
+    }`
+  }
+
+  instance.listener.pageScaleChange = function(payload) {
+    document.querySelector<HTMLSpanElement>(
+      '.page-scale-percentage'
+    )!.innerText = `${Math.floor(payload * 10 * 10)}%`
+  }
+
+  instance.listener.controlChange = function(payload) {
+    const disableMenusInControlContext = [
+      'table',
+      'hyperlink',
+      'separator',
+      'page-break',
+      'control'
+    ]
+    // 菜单操作权限
+    disableMenusInControlContext.forEach(menu => {
+      const menuDom = document.querySelector<HTMLDivElement>(
+        `.menu-item__${menu}`
+      )!
+      payload.state === ControlState.ACTIVE
+        ? menuDom.classList.add('disable')
+        : menuDom.classList.remove('disable')
+    })
+  }
+
+  instance.listener.pageModeChange = function(payload) {
+    const activeMode = pageModeOptionsDom.querySelector<HTMLLIElement>(
+      `[data-page-mode='${payload}']`
+    )!
+    pageModeOptionsDom
+      .querySelectorAll('li')
+      .forEach(li => li.classList.remove('active'))
+    activeMode.classList.add('active')
+  }
+
+  const handleContentChange = async function() {
+    // 字数
+    const wordCount = await instance.command.getWordCount()
+    document.querySelector<HTMLSpanElement>('.word-count')!.innerText = `${
+      wordCount || 0
+    }`
+  }
+  instance.listener.contentChange = debounce(handleContentChange, 200)
+  handleContentChange()
+
+  let url = ''
+  instance.listener.saved = function(payload) {
+    console.log('elementList: ', payload);
+    (document.getElementById('pdfDom')! as HTMLIFrameElement).src = ''
+    if (url) {
+      URL.revokeObjectURL(url)
+    }
+    const pdf = instance.command.getPdf({
+      beforeExport: (doc) => {
+        // add the font to jsPDF
+        // doc.addFileToVFS("MyFont.ttf", myFont);
+        doc.addFont('/canvas-editor/fonts/simfang.ttf', 'sim-fang', 'normal')
+      }
+    })
+    pdf.then((blob) => {
+      url = URL.createObjectURL(blob);
+      (document.getElementById('pdfDom')! as HTMLIFrameElement).src = url + '#toolbar=0'
+    })
+  }
+
+  // 9. 右键菜单注册
+  instance.register.contextMenuList([
+    {
+      name: '批注',
+      when: payload => {
+        return (
+          !payload.isReadonly &&
+          payload.editorHasSelection &&
+          payload.zone === EditorZone.MAIN
+        )
+      },
+      callback: (command: Command) => {
+        new Dialog({
+          title: '批注',
+          data: [
+            {
+              type: 'textarea',
+              label: '批注',
+              height: 100,
+              name: 'value',
+              required: true,
+              placeholder: '请输入批注'
+            }
+          ],
+          onConfirm: payload => {
+            const value = payload.find(p => p.name === 'value')?.value
+            if (!value) return
+            const groupId = command.executeSetGroup()
+            if (!groupId) return
+            commentList.push({
+              id: groupId,
+              content: value,
+              userName: 'Hufe',
+              rangeText: command.getRangeText(),
+              createdDate: new Date().toLocaleString()
+            })
+          }
+        })
+      }
+    },
+    {
+      name: '签名',
+      icon: 'signature',
+      when: payload => {
+        return !payload.isReadonly && payload.editorTextFocus
+      },
+      callback: (command: Command) => {
+        new Signature({
+          onConfirm(payload) {
+            if (!payload) return
+            const { value, width, height } = payload
+            if (!value || !width || !height) return
+            command.executeInsertElementList([
+              {
+                value,
+                width,
+                height,
+                type: ElementType.IMAGE
+              }
+            ])
+          }
+        })
+      }
+    },
+    {
+      name: '格式整理',
+      icon: 'word-tool',
+      when: payload => {
+        return !payload.isReadonly
+      },
+      callback: (command: Command) => {
+        command.executeWordTool()
+      }
+    }
+  ])
+
+  // 10. 快捷键注册
+  instance.register.shortcutList([
+    {
+      key: KeyMap.P,
+      mod: true,
+      isGlobal: true,
+      callback: (command: Command) => {
+        command.executePrint()
+      }
+    },
+    {
+      key: KeyMap.F,
+      mod: true,
+      isGlobal: true,
+      callback: (command: Command) => {
+        const text = command.getRangeText()
+        searchDom.click()
+        if (text) {
+          searchInputDom.value = text
+          instance.command.executeSearch(text)
+          setSearchResult()
+        }
+      }
+    },
+    {
+      key: KeyMap.MINUS,
+      ctrl: true,
+      isGlobal: true,
+      callback: (command: Command) => {
+        command.executePageScaleMinus()
+      }
+    },
+    {
+      key: KeyMap.EQUAL,
+      ctrl: true,
+      isGlobal: true,
+      callback: (command: Command) => {
+        command.executePageScaleAdd()
+      }
+    },
+    {
+      key: KeyMap.ZERO,
+      ctrl: true,
+      isGlobal: true,
+      callback: (command: Command) => {
+        command.executePageScaleRecovery()
+      }
+    }
+  ])
+}

--- a/src/style.css
+++ b/src/style.css
@@ -70,7 +70,20 @@ ul {
   align-items: center;
   position: relative;
 }
+.editor-and-pdf{
+  display: flex;
+  justify-content: space-evenly;
+}
+.pdf {
+  margin: 80px auto;
+  flex-grow: 1;
+  flex-shrink: 1;
+}
 
+.pdf embed{
+  width: 100%;
+  height: 100%;
+}
 .menu-item>div {
   width: 24px;
   height: 24px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import typescript from '@rollup/plugin-typescript'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import * as path from 'path'
+import { resolve } from 'node:url'
 
 export default defineConfig(({ mode }) => {
   const name = 'canvas-editor'
@@ -39,6 +40,12 @@ export default defineConfig(({ mode }) => {
   }
   return {
     base: `/${name}/`,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        pdf: resolve(__dirname, 'pdf.html'),
+      }
+    },
     server: {
       host: '0.0.0.0'
     }


### PR DESCRIPTION
希望作者可以考虑合并导出pdf功能。

虽然pdf可以通过很多方式导出，但通过编辑器本身导出，可以导出一个可以选择文字的pdf文件。一些场景会用到这样的功能。
另外，这省去了使用者对导出pdf工具的选择困难。

我在实现功能时，尽量保证原有代码不受影响，但依然没有把握一点没有影响到原有的 canvs 画图，希望您见谅。