### PR TITLE
修复：使用 getHtml 和 setHtml 时表格中的额外换行问题

### DIFF
--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -1407,7 +1407,6 @@ export function getElementListByHTML(
         // br元素与display:block元素需换行
         if (node.nodeName === 'BR') {
           if (isTable) {
-            console.log('Tableeneterfound : ', tableEnterFound)
             if (tableEnterFound) {
               elementList.push({
                 value: '\n'
@@ -1573,7 +1572,6 @@ export function getElementListByHTML(
           findTextNode(node)
           if (node.nodeType === 1 && n !== childNodes.length - 1) {
             const display = window.getComputedStyle(node as Element).display
-            console.log('DISPLAY : ', display)
 
             if (display === 'block') {
               elementList.push({

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -1387,9 +1387,12 @@ export interface IGetElementListByHTMLOption {
 
 export function getElementListByHTML(
   htmlText: string,
-  options: IGetElementListByHTMLOption
+  options: IGetElementListByHTMLOption,
+  isTable = false
 ): IElement[] {
   const elementList: IElement[] = []
+  let tableEnterFound = false
+
   function findTextNode(dom: Element | Node) {
     if (dom.nodeType === 3) {
       const element = convertTextNodeToElement(dom)
@@ -1400,11 +1403,22 @@ export function getElementListByHTML(
       const childNodes = dom.childNodes
       for (let n = 0; n < childNodes.length; n++) {
         const node = childNodes[n]
+
         // br元素与display:block元素需换行
         if (node.nodeName === 'BR') {
-          elementList.push({
-            value: '\n'
-          })
+          if (isTable) {
+            console.log('Tableeneterfound : ', tableEnterFound)
+            if (tableEnterFound) {
+              elementList.push({
+                value: '\n'
+              })
+            }
+            tableEnterFound = true
+          } else {
+            elementList.push({
+              value: '\n'
+            })
+          }
         } else if (node.nodeName === 'A') {
           const aElement = node as HTMLLinkElement
           const value = aElement.innerText
@@ -1504,7 +1518,8 @@ export function getElementListByHTML(
               const tableCell = <HTMLTableCellElement>tdElement
               const valueList = getElementListByHTML(
                 tableCell.innerHTML,
-                options
+                options,
+                true
               )
               const td: ITd = {
                 colspan: tableCell.colSpan,
@@ -1558,6 +1573,8 @@ export function getElementListByHTML(
           findTextNode(node)
           if (node.nodeType === 1 && n !== childNodes.length - 1) {
             const display = window.getComputedStyle(node as Element).display
+            console.log('DISPLAY : ', display)
+
             if (display === 'block') {
               elementList.push({
                 value: '\n'


### PR DESCRIPTION
Chinese:

此 PR 解决了一个问题：如果表格中的文本居中对齐，并且包含换行符，则每次使用 getHtml 和 setHtml 方法时，换行符的数量都会增加。此修复确保换行符保持一致，不会意外增加。

English: 
This PR resolves an issue where, if a table with text is center-aligned and contains new lines, the number of new lines increases each time the getHtml and setHtml methods are used. This fix ensures that the new lines remain consistent and do not increase unexpectedly.