### PR TITLE
修复：使用 getHtml 和 setHtml 时视频无法正确渲染的问题

### DIFF
--- a/src/editor/core/draw/particle/block/modules/IFrameBlock.ts
+++ b/src/editor/core/draw/particle/block/modules/IFrameBlock.ts
@@ -1,7 +1,7 @@
 import { IRowElement } from '../../../../../interface/Row'
 
 export class IFrameBlock {
-  private static readonly sandbox = ['allow-scripts', 'allow-same-origin']
+  public static readonly sandbox = ['allow-scripts', 'allow-same-origin']
   private element: IRowElement
 
   constructor(element: IRowElement) {

--- a/src/editor/core/draw/particle/block/modules/VideoBlock.ts
+++ b/src/editor/core/draw/particle/block/modules/VideoBlock.ts
@@ -15,7 +15,6 @@ export class VideoBlock {
     video.style.objectFit = 'contain'
     video.src = block.videoBlock?.src || ''
     video.controls = true
-    video.crossOrigin = 'anonymous'
     blockItemContainer.append(video)
   }
 }

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -1407,7 +1407,6 @@ export function getElementListByHTML(
         // br元素与display:block元素需换行
         if (node.nodeName === 'BR') {
           if (isTable) {
-            console.log('Tableeneterfound : ', tableEnterFound)
             if (tableEnterFound) {
               elementList.push({
                 value: '\n'
@@ -1573,7 +1572,6 @@ export function getElementListByHTML(
           findTextNode(node)
           if (node.nodeType === 1 && n !== childNodes.length - 1) {
             const display = window.getComputedStyle(node as Element).display
-            console.log('DISPLAY : ', display)
 
             if (display === 'block') {
               elementList.push({

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -9,6 +9,7 @@ import {
   splitText
 } from '.'
 import {
+  BlockType,
   EditorMode,
   ElementType,
   IEditorOption,
@@ -1249,6 +1250,17 @@ export function createDomFromElementList(
           img.height = element.height!
         }
         clipboardDom.append(img)
+      } else if (element.type === ElementType.BLOCK) {
+        if (
+          element.block?.type === BlockType.VIDEO &&
+          element.block.videoBlock?.src
+        ) {
+          const video = document.createElement('video')
+          video.src = element.block.videoBlock?.src
+          video.width = element.width!
+          video.height = element.height!
+          clipboardDom.append(video)
+        }
       } else if (element.type === ElementType.SEPARATOR) {
         const hr = document.createElement('hr')
         clipboardDom.append(hr)
@@ -1494,6 +1506,22 @@ export function getElementListByHTML(
               height,
               value: src,
               type: ElementType.IMAGE
+            })
+          }
+        } else if (node.nodeName === 'VIDEO') {
+          const { src, width, height } = node as any
+          if (src && width && height) {
+            elementList.push({
+              value: '',
+              type: ElementType.BLOCK,
+              block: {
+                type: BlockType.VIDEO,
+                videoBlock: {
+                  src: src
+                }
+              },
+              width: width,
+              height: height
             })
           }
         } else if (node.nodeName === 'TABLE') {

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -1387,9 +1387,12 @@ export interface IGetElementListByHTMLOption {
 
 export function getElementListByHTML(
   htmlText: string,
-  options: IGetElementListByHTMLOption
+  options: IGetElementListByHTMLOption,
+  isTable = false
 ): IElement[] {
   const elementList: IElement[] = []
+  let tableEnterFound = false
+
   function findTextNode(dom: Element | Node) {
     if (dom.nodeType === 3) {
       const element = convertTextNodeToElement(dom)
@@ -1400,11 +1403,22 @@ export function getElementListByHTML(
       const childNodes = dom.childNodes
       for (let n = 0; n < childNodes.length; n++) {
         const node = childNodes[n]
+
         // br元素与display:block元素需换行
         if (node.nodeName === 'BR') {
-          elementList.push({
-            value: '\n'
-          })
+          if (isTable) {
+            console.log('Tableeneterfound : ', tableEnterFound)
+            if (tableEnterFound) {
+              elementList.push({
+                value: '\n'
+              })
+            }
+            tableEnterFound = true
+          } else {
+            elementList.push({
+              value: '\n'
+            })
+          }
         } else if (node.nodeName === 'A') {
           const aElement = node as HTMLLinkElement
           const value = aElement.innerText
@@ -1504,7 +1518,8 @@ export function getElementListByHTML(
               const tableCell = <HTMLTableCellElement>tdElement
               const valueList = getElementListByHTML(
                 tableCell.innerHTML,
-                options
+                options,
+                true
               )
               const td: ITd = {
                 colspan: tableCell.colSpan,
@@ -1558,6 +1573,8 @@ export function getElementListByHTML(
           findTextNode(node)
           if (node.nodeType === 1 && n !== childNodes.length - 1) {
             const display = window.getComputedStyle(node as Element).display
+            console.log('DISPLAY : ', display)
+
             if (display === 'block') {
               elementList.push({
                 value: '\n'

--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -1399,12 +1399,9 @@ export interface IGetElementListByHTMLOption {
 
 export function getElementListByHTML(
   htmlText: string,
-  options: IGetElementListByHTMLOption,
-  isTable = false
+  options: IGetElementListByHTMLOption
 ): IElement[] {
   const elementList: IElement[] = []
-  let tableEnterFound = false
-
   function findTextNode(dom: Element | Node) {
     if (dom.nodeType === 3) {
       const element = convertTextNodeToElement(dom)
@@ -1418,18 +1415,9 @@ export function getElementListByHTML(
 
         // br元素与display:block元素需换行
         if (node.nodeName === 'BR') {
-          if (isTable) {
-            if (tableEnterFound) {
-              elementList.push({
-                value: '\n'
-              })
-            }
-            tableEnterFound = true
-          } else {
-            elementList.push({
-              value: '\n'
-            })
-          }
+          elementList.push({
+            value: '\n'
+          })
         } else if (node.nodeName === 'A') {
           const aElement = node as HTMLLinkElement
           const value = aElement.innerText
@@ -1545,8 +1533,7 @@ export function getElementListByHTML(
               const tableCell = <HTMLTableCellElement>tdElement
               const valueList = getElementListByHTML(
                 tableCell.innerHTML,
-                options,
-                true
+                options
               )
               const td: ITd = {
                 colspan: tableCell.colSpan,


### PR DESCRIPTION
此 PR 解决了一个问题：在编辑器中，使用 getHtml 获取内容后，再次使用 setHtml 设置内容时，视频无法正确渲染。此修复确保视频在内容获取和重新设置后能够正确显示。

This PR resolves an issue where videos in the editor were not rendering correctly after using the getHtml method and then setting the content again with setHtml. With this fix, videos will now render properly when the content is retrieved and set back in the editor.
