### PR TITLE
修复：使用 getHtml 和 setHtml 时表格宽度和对齐问题

### DIFF
--- a/src/editor/utils/element.ts
+++ b/src/editor/utils/element.ts
@@ -20,7 +20,8 @@ import {
   LocationPosition,
   RowFlex,
   TableBorder,
-  TdBorder
+  TdBorder,
+  VerticalAlign
 } from '..'
 import { IFrameBlock } from '../core/draw/particle/block/modules/IFrameBlock'
 import { LaTexParticle } from '../core/draw/particle/latex/LaTexParticle'
@@ -1557,6 +1558,10 @@ export function getElementListByHTML(
             colgroup: [],
             trList: []
           }
+
+          // colgroup
+          const colElements = tableElement.querySelectorAll('colgroup col')
+
           // 基础数据
           tableElement.querySelectorAll('tr').forEach(trElement => {
             const trHeightStr = window
@@ -1575,7 +1580,10 @@ export function getElementListByHTML(
               const td: ITd = {
                 colspan: tableCell.colSpan,
                 rowspan: tableCell.rowSpan,
-                value: valueList
+                value: valueList,
+                verticalAlign: window.getComputedStyle(tdElement)
+                  .verticalAlign as VerticalAlign,
+                width: +window.getComputedStyle(tdElement).width
               }
               if (tableCell.style.backgroundColor) {
                 td.backgroundColor = tableCell.style.backgroundColor
@@ -1593,7 +1601,7 @@ export function getElementListByHTML(
             const width = Math.ceil(options.innerWidth / tdCount)
             for (let i = 0; i < tdCount; i++) {
               element.colgroup!.push({
-                width
+                width: +(colElements[i].getAttribute('width') || width)
               })
             }
             elementList.push(element)


### PR DESCRIPTION
此 PR 解决了一个问题：在使用 getHtml 获取内容后，再次使用 setHtml 设置内容时，表格的宽度和对齐方式无法正确保持。此修复确保表格在内容获取和重新设置后能够保持正确的宽度和对齐方式。

English:
This PR resolves an issue where the table width and alignment were not preserved correctly when using the getHtml method and then setting the content again with setHtml. With this fix, the table now maintains its correct width and alignment after retrieving and resetting the content.