### PR TITLE
fix: allow replacing search results with empty string to enable deletion

### DIFF
--- a/src/editor/core/draw/interactive/Search.ts
+++ b/src/editor/core/draw/interactive/Search.ts
@@ -333,7 +333,7 @@ export class Search {
   public replace(payload: string, option?: IReplaceOption) {
     const isReadonly = this.draw.isReadonly()
     if (isReadonly) return
-    if (!payload || new RegExp(`${ZERO}`, 'g').test(payload)) return
+    if (payload === undefined || payload === null) return;
     let matchList = this.getSearchMatchList()
     // 替换搜索项
     const replaceIndex = option?.index
@@ -383,6 +383,14 @@ export class Search {
         ) {
           continue
         }
+        if (payload === "") {
+          this.draw.spliceElementList(tableElementList, curIndex, 1)
+          tableDiffCount--;
+          if (!~firstMatchIndex) {
+            firstMatchIndex = m
+          }
+          continue
+        }
         if (curGroupId === match.groupId) {
           this.draw.spliceElementList(tableElementList, curIndex, 1)
           tableDiffCount--
@@ -417,6 +425,14 @@ export class Search {
             element.controlComponent !== ControlComponent.VALUE)
         ) {
           continue
+        }
+         if (payload === "") {
+          this.draw.spliceElementList(elementList, curIndex, 1);
+          pageDiffCount--;
+          if (!~firstMatchIndex) {
+            firstMatchIndex = m
+          }
+          continue;
         }
         if (!~firstMatchIndex) {
           firstMatchIndex = m

--- a/src/editor/core/draw/interactive/Search.ts
+++ b/src/editor/core/draw/interactive/Search.ts
@@ -333,7 +333,7 @@ export class Search {
   public replace(payload: string, option?: IReplaceOption) {
     const isReadonly = this.draw.isReadonly()
     if (isReadonly) return
-    if (payload === undefined || payload === null) return;
+    if (payload === undefined || payload === null) return
     let matchList = this.getSearchMatchList()
     // 替换搜索项
     const replaceIndex = option?.index
@@ -383,9 +383,9 @@ export class Search {
         ) {
           continue
         }
-        if (payload === "") {
+        if (payload === '') {
           this.draw.spliceElementList(tableElementList, curIndex, 1)
-          tableDiffCount--;
+          tableDiffCount--
           if (!~firstMatchIndex) {
             firstMatchIndex = m
           }
@@ -426,13 +426,13 @@ export class Search {
         ) {
           continue
         }
-         if (payload === "") {
-          this.draw.spliceElementList(elementList, curIndex, 1);
-          pageDiffCount--;
+        if (payload === '') {
+          this.draw.spliceElementList(elementList, curIndex, 1)
+          pageDiffCount--
           if (!~firstMatchIndex) {
             firstMatchIndex = m
           }
-          continue;
+          continue
         }
         if (!~firstMatchIndex) {
           firstMatchIndex = m

--- a/src/main.ts
+++ b/src/main.ts
@@ -1219,7 +1219,7 @@ window.onload = function () {
     function () {
       const searchValue = searchInputDom.value
       const replaceValue = replaceInputDom.value
-      if (searchValue && replaceValue && searchValue !== replaceValue) {
+      if (searchValue && searchValue !== replaceValue) {
         instance.command.executeReplace(replaceValue)
       }
     }


### PR DESCRIPTION
Hi!
I opened this PR to allow the executeReplace command to delete text when replacing with an empty string ("").
Previously, replacing with an empty string had no effect — the original text remained unchanged.
This change makes it possible to remove text via the API by passing an empty string as the replacement.

Let me know if any adjustments are needed. Thanks!