### PR TITLE
修复windows下pasteByApi中比较剪贴板和localStorage时没有抹平\r\n差异

### DIFF
--- a/src/editor/core/event/handlers/paste.ts
+++ b/src/editor/core/event/handlers/paste.ts
@@ -179,7 +179,11 @@ export async function pasteByApi(host: CanvasEvent, options?: IPasteOption) {
   // 优先读取编辑器内部粘贴板数据
   const clipboardText = await navigator.clipboard.readText()
   const editorClipboardData = getClipboardData()
-  if (clipboardText === editorClipboardData?.text) {
+  if (
+    editorClipboardData &&
+    normalizeLineBreak(clipboardText) ===
+      normalizeLineBreak(editorClipboardData.text)
+  ) {
     pasteElement(host, editorClipboardData.elementList)
     return
   }


### PR DESCRIPTION
## 问题描述
使用executePaste粘贴表格时，发现跟手动粘贴的表格内容样式不一致（这个是另外问题，不延申）。后来排查代码发现是executePaste没有走手动粘贴触发的pasteByEvent中的pasteElement函数，导致的表现不一致。

## 涉及代码
```typescript
// canvas-editor\src\editor\utils\clipboard.ts
export function writeClipboardItem(
  text: string,
  html: string,
  elementList: IElement[]
) {
  if (!text && !html && !elementList.length) return
  const plainText = new Blob([text], { type: 'text/plain' })
  const htmlText = new Blob([html], { type: 'text/html' })
  if (window.ClipboardItem) {
    // @ts-ignore
    const item = new ClipboardItem({
      [plainText.type]: plainText,
      [htmlText.type]: htmlText
    })
    // 【笔者注】这里写入的item换行符为\r
    window.navigator.clipboard.write([item])
  } else {
   // 省略
```

```typescript
// canvas-editor\src\editor\core\event\handlers\paste.ts
export async function pasteByApi(host: CanvasEvent, options?: IPasteOption) {
  const draw = host.getDraw()
  if (draw.isReadonly() || draw.isDisabled()) return
  // 自定义粘贴事件
  const { paste } = draw.getOverride()
  if (paste) {
    const overrideResult = paste()
    // 默认阻止默认事件
    if ((<IOverrideResult>overrideResult)?.preventDefault !== false) return
  }
  // 优先读取编辑器内部粘贴板数据
  // 【笔者注】这里取出来的clipboardText换行符为\r\n
  const clipboardText = await navigator.clipboard.readText()
  const editorClipboardData = getClipboardData()
  // 【笔者注】下面这个if永远进不去
  if (clipboardText === editorClipboardData?.text) {
    pasteElement(host, editorClipboardData.elementList)
    return
  }
  removeClipboardData()
  // 省略
```
## 解决方案
```typescript
// 【笔者注】借用pasteByEvent中处理\r\n的逻辑，保持风格一致性
if (
    editorClipboardData &&
    normalizeLineBreak(clipboardText) ===
      normalizeLineBreak(editorClipboardData.text)
  ) {
    pasteElement(host, editorClipboardData.elementList)
    return
  }
```