### PR TITLE
fix: latex公式绘制前clearRect避免公式重叠

### DIFF
--- a/src/editor/core/draw/particle/latex/LaTexParticle.ts
+++ b/src/editor/core/draw/particle/latex/LaTexParticle.ts
@@ -23,12 +23,14 @@ export class LaTexParticle extends ImageParticle {
     const height = element.height! * scale
     if (this.imageCache.has(element.value)) {
       const img = this.imageCache.get(element.value)!
+      ctx.clearRect(x, y, width, height)
       ctx.drawImage(img, x, y, width, height)
     } else {
       const laTexLoadPromise = new Promise((resolve, reject) => {
         const img = new Image()
         img.src = element.laTexSVG!
         img.onload = () => {
+          ctx.clearRect(x, y, width, height)
           ctx.drawImage(img, x, y, width, height)
           this.imageCache.set(element.value, img)
           resolve(element)


### PR DESCRIPTION
发现渲染editor时，latex绘制公式时候会重复绘制多次，由于latex为svg，转为img时候是透明背景，会导致公式重复叠加，导致公式加粗

原代码表现
<img width="1256" height="636" alt="QQ20251017-093559" src="https://github.com/user-attachments/assets/0f181eb9-d7fc-4bd8-b387-912bc5b05390" />

新代码表现
<img width="1081" height="591" alt="QQ20251017-094029" src="https://github.com/user-attachments/assets/c22e15b6-cf52-4f52-a17c-36da00e8919d" />
