### PR TITLE
fix: 赋予空格等无actualBoundingBoxAscent高度元素默认高度，以修复新行光标错误问题

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1737,7 +1737,7 @@ export class Draw {
         metrics.boundingBoxAscent =
           (element.value === ZERO
             ? element.size || defaultSize
-            : fontMetrics.actualBoundingBoxAscent) * scale
+            : fontMetrics.actualBoundingBoxAscent || defaultSize) * scale
         metrics.boundingBoxDescent =
           fontMetrics.actualBoundingBoxDescent * scale
         if (element.type === ElementType.SUPERSCRIPT) {


### PR DESCRIPTION
发现连续输入空格直至新行创建时，光标表现有误
官网表现：
<img width="1283" height="458" alt="ScreenShot_2025-11-18_164156_311" src="https://github.com/user-attachments/assets/a5038d8c-2ca0-4dbc-bc1a-92b1981e6ac6" />

相关代码：
https://github.com/Hufe921/canvas-editor/blob/main/src/editor/core/draw/Draw.ts#L1732
经查代码发现是measureText在对空格测高时actualBoundingBoxAscent为-0，导致行高过小导致光标错乱

修复方式：
参考作者对ZERO元素的操作，赋予当actualBoundingBoxAscent为0时一个默认值defaultSize

修复后表现：
<img width="1272" height="421" alt="ScreenShot_2025-11-18_164215_991" src="https://github.com/user-attachments/assets/5088bc60-a515-400f-b017-5f9a306ca24b" />
