### PR TITLE
fix: 绘制公式前清除原公式，避免字符重叠绘制问题

### DIFF
--- a/src/editor/core/draw/particle/latex/LaTexParticle.ts
+++ b/src/editor/core/draw/particle/latex/LaTexParticle.ts
@@ -23,12 +23,14 @@ export class LaTexParticle extends ImageParticle {
     const height = element.height! * scale
     if (this.imageCache.has(element.value)) {
       const img = this.imageCache.get(element.value)!
+      ctx.clearRect(x, y, width, height)
       ctx.drawImage(img, x, y, width, height)
     } else {
       const laTexLoadPromise = new Promise((resolve, reject) => {
         const img = new Image()
         img.src = element.laTexSVG!
         img.onload = () => {
+          ctx.clearRect(x, y, width, height)
           ctx.drawImage(img, x, y, width, height)
           this.imageCache.set(element.value, img)
           resolve(element)


### PR DESCRIPTION
发现使用连页模式下，绘制公式前没有清除原公式内容导致公式叠影。

复现代码：https://codesandbox.io/p/sandbox/vigilant-bouman-8x483c

<img width="1574" height="859" alt="image" src="https://github.com/user-attachments/assets/26eeba16-c24b-44e6-b3d5-4403a7393d1d" />

可以观察到旧的公式会被重叠绘制


发现是使用[_immediateRender](https://github.com/Hufe921/canvas-editor/blob/main/src/editor/core/draw/Draw.ts#L2705)渲染公式时候就会出现这个问题

历史相关issue：
#1284 