### PR TITLE
feat: Add optional 'radio'/'checkbox' to SELECT control popup / 为 SELECT 控件弹窗添加视觉样式选项

### DIFF
--- a/docs/en/guide/schema.md
+++ b/docs/en/guide/schema.md
@@ -125,6 +125,7 @@ interface IElement {
     }[];
     isMultiSelect?: boolean;
     multiSelectDelimiter?: string;
+    selectStyle?: 'checkbox' | 'radio';
     dateFormat?: string;
     font?: string;
     size?: number;

--- a/docs/guide/schema.md
+++ b/docs/guide/schema.md
@@ -125,6 +125,7 @@ interface IElement {
     }[];
     isMultiSelect?: boolean;
     multiSelectDelimiter?: string;
+    selectStyle?: 'checkbox' | 'radio';
     dateFormat?: string;
     font?: string;
     size?: number;

--- a/src/editor/assets/css/control/select.css
+++ b/src/editor/assets/css/control/select.css
@@ -42,3 +42,14 @@
   color: var(--COLOR-HOVER, #5175f4);
   font-weight: 700;
 }
+
+.ce-select-checkbox,
+.ce-select-radio {
+  margin-right: 8px;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+.ce-select-control-popup ul li span {
+  vertical-align: middle;
+}

--- a/src/editor/core/draw/control/select/SelectControl.ts
+++ b/src/editor/core/draw/control/select/SelectControl.ts
@@ -495,9 +495,25 @@ export class SelectControl implements IControlInstance {
       const valueSet = valueSets[v]
       const li = document.createElement('li')
       let codes = this.getCodes()
-      if (codes.includes(valueSet.code)) {
+      const isChecked = codes.includes(valueSet.code)
+
+      // 添加选择框（复选框或单选框）
+      let inputElement: HTMLInputElement | null = null
+      if (
+        control.selectStyle === 'checkbox' ||
+        control.selectStyle === 'radio'
+      ) {
+        inputElement = document.createElement('input')
+        inputElement.type = control.selectStyle
+        inputElement.checked = isChecked
+        inputElement.className = `${EDITOR_PREFIX}-select-${control.selectStyle}`
+        li.append(inputElement)
+      }
+
+      if (isChecked) {
         li.classList.add('active')
       }
+
       li.onclick = () => {
         const codeIndex = codes.findIndex(code => code === valueSet.code)
         if (control.isMultiSelect) {
@@ -515,7 +531,10 @@ export class SelectControl implements IControlInstance {
         }
         this.setSelect(codes.join(this.VALUE_DELIMITER))
       }
-      li.append(document.createTextNode(valueSet.value))
+
+      const span = document.createElement('span')
+      span.append(document.createTextNode(valueSet.value))
+      li.append(span)
       ul.append(li)
     }
     selectPopupContainer.append(ul)

--- a/src/editor/interface/Control.ts
+++ b/src/editor/interface/Control.ts
@@ -23,6 +23,7 @@ export interface IControlSelect {
   valueSets: IValueSet[]
   isMultiSelect?: boolean
   multiSelectDelimiter?: string
+  selectStyle?: 'checkbox' | 'radio'
   selectExclusiveOptions?: {
     inputAble?: boolean
   }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -392,6 +392,101 @@ elementList.push(
   ])
 )
 
+// 多选下拉控件（复选框样式）
+elementList.push(
+  ...(<IElement[]>[
+    {
+      value: '过敏史：'
+    },
+    {
+      type: ElementType.CONTROL,
+      value: '',
+      control: {
+        conceptId: '8',
+        type: ControlType.SELECT,
+        value: null,
+        code: null,
+        placeholder: '请选择',
+        prefix: '{',
+        postfix: '}',
+        isMultiSelect: true,
+        selectStyle: 'checkbox',
+        multiSelectDelimiter: '、',
+        valueSets: [
+          {
+            value: '青霉素',
+            code: 'penicillin'
+          },
+          {
+            value: '头孢',
+            code: 'cephalosporin'
+          },
+          {
+            value: '磺胺',
+            code: 'sulfonamide'
+          },
+          {
+            value: '海鲜',
+            code: 'seafood'
+          },
+          {
+            value: '花粉',
+            code: 'pollen'
+          }
+        ]
+      }
+    },
+    {
+      value: '\n'
+    }
+  ])
+)
+
+// 单选下拉控件（单选框样式）
+elementList.push(
+  ...(<IElement[]>[
+    {
+      value: '血型：'
+    },
+    {
+      type: ElementType.CONTROL,
+      value: '',
+      control: {
+        conceptId: '9',
+        type: ControlType.SELECT,
+        value: null,
+        code: null,
+        placeholder: '请选择',
+        prefix: '{',
+        postfix: '}',
+        isMultiSelect: false,
+        selectStyle: 'radio',
+        valueSets: [
+          {
+            value: 'A型',
+            code: 'A'
+          },
+          {
+            value: 'B型',
+            code: 'B'
+          },
+          {
+            value: 'AB型',
+            code: 'AB'
+          },
+          {
+            value: 'O型',
+            code: 'O'
+          }
+        ]
+      }
+    },
+    {
+      value: '\n'
+    }
+  ])
+)
+
 // 日期选择
 elementList.push(
   ...(<IElement[]>[


### PR DESCRIPTION
## Description / 描述

Add `selectStyle` property to SELECT control to display checkboxes or radio buttons in the popup, improving
UX clarity.

为 SELECT 控件添加 `selectStyle` 属性，可在弹窗中显示复选框或单选框，提升用户体验清晰度。

## Changes / 变更

- Add `selectStyle?: 'checkbox' | 'radio'` property to `IControlSelect` /  添加 `selectStyle?: 'checkbox' | 'radio'` 属性到 `IControlSelect`

- Update documentation and add test examples / 更新文档并添加测试示例

## Examples / 示例

```ts
// Checkbox visual + multi-select / 复选框视觉 + 多选
{ selectStyle: 'checkbox', isMultiSelect: true }
```

<img width="555" height="599" alt="Screenshot From 2025-12-03 18-05-06" src="https://github.com/user-attachments/assets/828220e4-f5b8-468c-85a7-094a99ff099d" />


```ts
// Radio visual + single-select / 单选框视觉 + 单选
{ selectStyle: 'radio', isMultiSelect: false }
```

<img width="434" height="509" alt="Screenshot From 2025-12-03 18-05-30" src="https://github.com/user-attachments/assets/b8901bfd-fc9d-43aa-8f65-0bf079df1591" />
