### PR TITLE
fix: 修复新行字符上升高度小于等于零导致行塌陷问题

### DIFF
--- a/src/editor/core/draw/Draw.ts
+++ b/src/editor/core/draw/Draw.ts
@@ -1897,6 +1897,23 @@ export class Draw {
           rowFlex: elementList[i]?.rowFlex || elementList[i + 1]?.rowFlex,
           isPageBreak: element.type === ElementType.PAGE_BREAK
         }
+        // 有些字符的上升高度可能是负数，比如下划线
+        // 所以行高大于等于上身高度时，赋予一个基础的上升高度避免行塌陷
+        // 比如整行都是空格，行上升高度为rowMargin
+        // 比如整行都是下划线，行上升高度小于rowMargin
+        // 要注意表格的上升高度为0，所以要判断元素类型是否为文本
+        if (
+          (!element.type || element.type === ElementType.TEXT) &&
+          row.ascent <= rowMargin
+        ) {
+          const boundingBoxAscent =
+            this.textParticle.getBasisWordBoundingBoxAscent(
+              ctx,
+              element.font!
+            ) * scale
+          row.ascent = rowMargin + boundingBoxAscent
+          row.height = rowMargin + boundingBoxAscent
+        }
         // 控件缩进
         if (
           rowElement.controlComponent !== ControlComponent.PREFIX &&
@@ -1971,17 +1988,6 @@ export class Draw {
             el.metrics.width += gap
           }
           curRow.width = availableWidth
-        }
-        // 行距离顶部偏移量等于行高时 => 行增加默认标准元素偏移量
-        // 如整行都是空格测量偏移量为0，导致行塌陷
-        if (curRow.ascent === rowMargin) {
-          const boundingBoxDescent =
-            this.textParticle.getBasisWordBoundingBoxAscent(
-              ctx,
-              element.font!
-            ) * scale
-          curRow.ascent += boundingBoxDescent
-          curRow.height += boundingBoxDescent
         }
       }
       // 重新计算坐标、页码、下一行首行元素环绕交叉


### PR DESCRIPTION
之前在 #1313 pr反馈过空格折行会触发行塌陷的问题，现在发现下划线折行也会触发行塌陷。
应该是因为下划线的上升高度为负数，作者原来的判断===没有进入，作者修改的是curRow.ascent，没有更新新行的ascent导致。
尝试修复了一下，做为抛砖引玉。

update: 目前发现表格的行上升高度为0，会误入新增逻辑，添加了类型校验

修复前（官网版本）：
<img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/166882d4-aba9-4437-b2f2-ca8f097e1383" />

修复后：
<img width="1918" height="984" alt="image" src="https://github.com/user-attachments/assets/f8880ac1-751b-4818-b550-5ce8e5793662" />
