### PR TITLE
feat: add checkMarkColor option for checkbox

### DIFF
--- a/docs/en/guide/option.md
+++ b/docs/en/guide/option.md
@@ -64,7 +64,7 @@ interface IEditorOption {
   wordBreak?: WordBreak // Word and punctuation breaks: No punctuation in the first line of the BREAK_WORD &The word is not split, and the line is folded after BREAK_ALL full according to the width of the character. default: BREAK_WORD
   watermark?: IWatermark // Watermark{data:string; color?:string; opacity?:number; size?:number; font?:string; numberType:NumberType;}
   control?: IControlOption // Control {placeholderColor?:string; bracketColor?:string; prefix?:string; postfix?:string; borderWidth?: number; borderColor?: string; activeBackgroundColor?: string; disabledBackgroundColor?: string; existValueBackgroundColor?: string; noValueBackgroundColor?: string;}
-  checkbox?: ICheckboxOption // Checkbox {width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; verticalAlign?: VerticalAlign;}
+  checkbox?: ICheckboxOption // Checkbox {width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; checkFillStyle?: string; checkStrokeStyle?: string; checkMarkColor?: string; verticalAlign?: VerticalAlign;}
   radio?: IRadioOption // Radio {width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; verticalAlign?: VerticalAlign;}
   cursor?: ICursorOption // Cursor style. {width?: number; color?: string; dragWidth?: number; dragColor?: string; dragFloatImageDisabled?: boolean;}
   title?: ITitleOption // Title configuration.{ defaultFirstSize?: number; defaultSecondSize?: number; defaultThirdSize?: number defaultFourthSize?: number; defaultFifthSize?: number; defaultSixthSize?: number;}

--- a/docs/guide/option.md
+++ b/docs/guide/option.md
@@ -64,7 +64,7 @@ interface IEditorOption {
   wordBreak?: WordBreak // 单词与标点断行：BREAK_WORD首行不出现标点&单词不拆分、BREAK_ALL按字符宽度撑满后折行。默认：BREAK_WORD
   watermark?: IWatermark // 水印信息。{data:string; color?:string; opacity?:number; size?:number; font?:string; numberType:NumberType;}
   control?: IControlOption // 控件信息。 {placeholderColor?:string; bracketColor?:string; prefix?:string; postfix?:string; borderWidth?: number; borderColor?: string; activeBackgroundColor?: string; disabledBackgroundColor?: string; existValueBackgroundColor?: string; noValueBackgroundColor?: string;}
-  checkbox?: ICheckboxOption // 复选框信息。{width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; verticalAlign?: VerticalAlign;}
+  checkbox?: ICheckboxOption // 复选框信息。{width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; checkFillStyle?: string; checkStrokeStyle?: string; checkMarkColor?: string; verticalAlign?: VerticalAlign;}
   radio?: IRadioOption // 单选框信息。{width?:number; height?:number; gap?:number; lineWidth?:number; fillStyle?:string; strokeStyle?: string; verticalAlign?: VerticalAlign;}
   cursor?: ICursorOption // 光标样式。{width?: number; color?: string; dragWidth?: number; dragColor?: string; dragFloatImageDisabled?: boolean;}
   title?: ITitleOption // 标题配置。{ defaultFirstSize?: number; defaultSecondSize?: number; defaultThirdSize?: number defaultFourthSize?: number; defaultFifthSize?: number; defaultSixthSize?: number;}

--- a/src/editor/core/draw/particle/CheckboxParticle.ts
+++ b/src/editor/core/draw/particle/CheckboxParticle.ts
@@ -47,6 +47,8 @@ export class CheckboxParticle {
         lineWidth,
         fillStyle,
         strokeStyle,
+        checkFillStyle,
+        checkStrokeStyle,
         checkMarkColor,
         verticalAlign
       },
@@ -90,24 +92,31 @@ export class CheckboxParticle {
     ctx.translate(0.5, 0.5)
     // 绘制勾选状态
     if (checkbox?.value) {
-      ctx.fillStyle = fillStyle
+      // 选中时填充背景
+      ctx.fillStyle = checkFillStyle
       ctx.fillRect(left, top, width, height)
-      //绘制边框
+      // 选中时绘制边框
       ctx.beginPath()
       ctx.lineWidth = lineWidth
-      ctx.strokeStyle = strokeStyle 
+      ctx.strokeStyle = checkStrokeStyle
       ctx.rect(left, top, width, height)
       ctx.stroke()
-      //勾选对号
+      // 勾选对号
       ctx.beginPath()
-      ctx.strokeStyle = checkMarkColor  // 需要新增一个配置项
+      ctx.strokeStyle = checkMarkColor
       ctx.lineWidth = lineWidth * 2 * scale
       ctx.moveTo(left + 2 * scale, top + height / 2)
       ctx.lineTo(left + width / 2, top + height - 3 * scale)
       ctx.lineTo(left + width - 2 * scale, top + 3 * scale)
       ctx.stroke()
     } else {
+      // 未选中时填充背景
+      ctx.fillStyle = fillStyle
+      ctx.fillRect(left, top, width, height)
+      // 未选中时绘制边框
+      ctx.beginPath()
       ctx.lineWidth = lineWidth
+      ctx.strokeStyle = strokeStyle
       ctx.rect(left, top, width, height)
       ctx.stroke()
     }

--- a/src/editor/dataset/constant/Checkbox.ts
+++ b/src/editor/dataset/constant/Checkbox.ts
@@ -6,8 +6,10 @@ export const defaultCheckboxOption: Readonly<Required<ICheckboxOption>> = {
   height: 14,
   gap: 5,
   lineWidth: 1,
-  fillStyle: '#fff',//勾选框填充色
-  strokeStyle: '#000',//勾选框边框色
-  checkMarkColor: '#000',//勾选图标颜色
+  fillStyle: '#ffffff', // 未选中时填充色
+  strokeStyle: '#000000', // 未选中时边框色
+  checkFillStyle: '#5175f4', // 选中时填充色
+  checkStrokeStyle: '#5175f4', // 选中时边框色
+  checkMarkColor: '#ffffff', // 选中时对勾颜色
   verticalAlign: VerticalAlign.BOTTOM
 }

--- a/src/editor/interface/Checkbox.ts
+++ b/src/editor/interface/Checkbox.ts
@@ -13,6 +13,8 @@ export interface ICheckboxOption {
   lineWidth?: number
   fillStyle?: string
   strokeStyle?: string
+  checkFillStyle?: string
+  checkStrokeStyle?: string
   checkMarkColor?: string
   verticalAlign?: VerticalAlign
 }


### PR DESCRIPTION
#Problem Description

When setting checkbox without background color, encountered a rendering order issue that caused the border to be covered:

Original Rendering Order (checked state):
1. Draw border - using `strokeStyle`
2. Fill background - using `fillStyle` to fill the entire box
3. Draw checkmark - using `strokeStyle` to draw ✓


When needing to set checkbox without background color (transparent), showing only border and checkmark, the expected effect cannot be achieved.

<img width="446" height="45" alt="image" src="https://github.com/user-attachments/assets/84d42b6f-b08a-44ff-a83b-faae243bbdeb" />

#Solution

1. Add New Configuration `checkMarkColor`
2. Update rendering logic


export interface ICheckboxOption {
  width?: number
  height?: number
  gap?: number
  lineWidth?: number
  fillStyle?: string        // Background fill color
  strokeStyle?: string      // Border color
  checkMarkColor?: string   // Checkmark color (new)
  verticalAlign?: VerticalAlign
}