### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/src/editor/utils/index.ts
+++ b/src/editor/utils/index.ts
@@ -195,6 +195,9 @@ export function mergeObject<T>(source: T, target: T): T {
   if (isObject(source) && isObject(target)) {
     const objectTarget = <Record<string, unknown>>target
     for (const [key, val] of Object.entries(source)) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue
+      }
       if (!objectTarget[key]) {
         objectTarget[key] = val
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Hufe921/canvas-editor/security/code-scanning/4](https://github.com/Hufe921/canvas-editor/security/code-scanning/4)

To fix prototype pollution safely without changing intended merge behavior, add a guard that blocks dangerous property keys (`__proto__`, `constructor`, `prototype`) before any write or recursive descent.

Best approach in this file:
- In `src/editor/utils/index.ts`, inside `mergeObject`’s object-merge loop (around lines 197–203), skip entries where `key` is one of those forbidden names.
- Keep existing merge behavior for all other keys.
- No new dependency is required; no import changes needed.

This prevents writes such as `objectTarget["__proto__"] = ...` and recursive traversal through `constructor.prototype` chains, which are common prototype pollution vectors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
