### PR TITLE
fix: correct insertion in merged tables

### DIFF
--- a/src/editor/core/draw/particle/table/TableOperate.ts
+++ b/src/editor/core/draw/particle/table/TableOperate.ts
@@ -4,6 +4,7 @@ import { TABLE_CONTEXT_ATTR } from '../../../../dataset/constant/Element'
 import { TdBorder, TdSlash } from '../../../../dataset/enum/table/Table'
 import { DeepRequired } from '../../../../interface/Common'
 import { IEditorOption } from '../../../../interface/Editor'
+import { IPositionContext } from '../../../../interface/Position'
 import { IColgroup } from '../../../../interface/table/Colgroup'
 import { ITd } from '../../../../interface/table/Td'
 import { ITr } from '../../../../interface/table/Tr'
@@ -98,131 +99,135 @@ export class TableOperate {
     this.draw.render({ curIndex, isSetCursor: false })
   }
 
-  public insertTableTopRow() {
-    const positionContext = this.position.getPositionContext()
-    if (!positionContext.isTable) return
-    const { index, trIndex, tableId } = positionContext
-    const originalElementList = this.draw.getOriginalElementList()
-    const element = originalElementList[index!]
-    const curTrList = element.trList!
-    const curTr = curTrList[trIndex!]
-    // 之前跨行的增加跨行数
-    if (curTr.tdList.length < element.colgroup!.length) {
-      const curTrNo = curTr.tdList[0].rowIndex!
-      for (let t = 0; t < trIndex!; t++) {
-        const tr = curTrList[t]
-        for (let d = 0; d < tr.tdList.length; d++) {
-          const td = tr.tdList[d]
-          if (td.rowspan > 1 && td.rowIndex! + td.rowspan >= curTrNo + 1) {
-            td.rowspan += 1
-          }
+  private _createEmptyTd(tableId: string | undefined, trId: string | undefined) {
+    const tdId = getUUID()
+    return {
+      id: tdId,
+      rowspan: 1,
+      colspan: 1,
+      value: [
+        {
+          value: ZERO,
+          size: 16,
+          tableId,
+          trId,
+          tdId
+        }
+      ]
+    }
+  }
+
+  private _setTablePosition(
+    positionContext: IPositionContext,
+    element: IElement,
+    targetTd: ITd
+  ) {
+    const trList = element.trList!
+    const trIndex = trList.findIndex(tr => tr.tdList.includes(targetTd))
+    if (!~trIndex) return
+    const tr = trList[trIndex]
+    const tdIndex = tr.tdList.indexOf(targetTd)
+    this.position.setPositionContext(
+      this.position.buildTablePositionContext(
+        positionContext,
+        element,
+        trIndex,
+        tdIndex
+      )
+    )
+  }
+
+  private _insertTableRow(
+    positionContext: IPositionContext,
+    element: IElement,
+    rowIndex: number,
+    height: number
+  ) {
+    const trList = element.trList!
+    const colgroup = element.colgroup!
+    const spanningTdList: ITd[] = []
+    for (let t = 0; t < trList.length; t++) {
+      const tdList = trList[t].tdList
+      for (let d = 0; d < tdList.length; d++) {
+        const td = tdList[d]
+        if (
+          td.rowIndex! < rowIndex &&
+          td.rowIndex! + td.rowspan > rowIndex
+        ) {
+          td.rowspan++
+          spanningTdList.push(td)
         }
       }
     }
-    // 增加当前行
+
+    const coveredColSet = new Set<number>()
+    for (let t = 0; t < spanningTdList.length; t++) {
+      const td = spanningTdList[t]
+      for (let c = 0; c < td.colspan; c++) {
+        coveredColSet.add(td.colIndex! + c)
+      }
+    }
     const newTrId = getUUID()
     const newTr: ITr = {
-      height: curTr.height,
+      height,
       id: newTrId,
       tdList: []
     }
-    for (let t = 0; t < curTr.tdList.length; t++) {
-      const curTd = curTr.tdList[t]
-      const newTdId = getUUID()
-      newTr.tdList.push({
-        id: newTdId,
-        rowspan: 1,
-        colspan: curTd.colspan,
-        value: [
-          {
-            value: ZERO,
-            size: 16,
-            tableId,
-            trId: newTrId,
-            tdId: newTdId
-          }
-        ]
-      })
+    for (let c = 0; c < colgroup.length; c++) {
+      if (!coveredColSet.has(c)) {
+        newTr.tdList.push(this._createEmptyTd(element.id, newTrId))
+      }
     }
-    curTrList.splice(trIndex!, 0, newTr)
-    // 重新设置上下文
-    this.position.setPositionContext({
-      isTable: true,
-      index,
-      trIndex,
-      tdIndex: 0,
-      tdId: newTr.tdList[0].id,
-      trId: newTr.id,
-      tableId
-    })
+    trList.splice(rowIndex, 0, newTr)
+
+    const targetTd =
+      newTr.tdList[0] ||
+      spanningTdList.find(
+        td => td.colIndex! <= 0 && td.colIndex! + td.colspan > 0
+      ) ||
+      spanningTdList[0]
+    if (targetTd) {
+      this._setTablePosition(positionContext, element, targetTd)
+    }
     this.range.setRange(0, 0)
-    // 重新渲染
     this.draw.render({ curIndex: 0 })
     this.tableTool.render()
+  }
+
+  public insertTableTopRow() {
+    const positionContext = this.position.getPositionContext()
+    if (!positionContext.isTable) return
+    const { trIndex, tdIndex } = positionContext
+    const originalElementList = this.draw.getOriginalElementList()
+    const element = this.position.getTableElementByContext(
+      originalElementList,
+      positionContext
+    )!
+    const curTr = element.trList![trIndex!]
+    const curTd = curTr.tdList[tdIndex!]
+    this._insertTableRow(
+      positionContext,
+      element,
+      curTd.rowIndex!,
+      curTr.height
+    )
   }
 
   public insertTableBottomRow() {
     const positionContext = this.position.getPositionContext()
     if (!positionContext.isTable) return
-    const { index, trIndex, tableId } = positionContext
+    const { trIndex, tdIndex } = positionContext
     const originalElementList = this.draw.getOriginalElementList()
-    const element = originalElementList[index!]
-    const curTrList = element.trList!
-    const curTr = curTrList[trIndex!]
-    const anchorTr =
-      curTrList.length - 1 === trIndex ? curTr : curTrList[trIndex! + 1]
-    // 之前/当前行跨行的增加跨行数
-    if (anchorTr.tdList.length < element.colgroup!.length) {
-      const curTrNo = anchorTr.tdList[0].rowIndex!
-      for (let t = 0; t < trIndex! + 1; t++) {
-        const tr = curTrList[t]
-        for (let d = 0; d < tr.tdList.length; d++) {
-          const td = tr.tdList[d]
-          if (td.rowspan > 1 && td.rowIndex! + td.rowspan >= curTrNo + 1) {
-            td.rowspan += 1
-          }
-        }
-      }
-    }
-    // 增加当前行
-    const newTrId = getUUID()
-    const newTr: ITr = {
-      height: anchorTr.height,
-      id: newTrId,
-      tdList: []
-    }
-    for (let t = 0; t < anchorTr.tdList.length; t++) {
-      const curTd = anchorTr.tdList[t]
-      const newTdId = getUUID()
-      newTr.tdList.push({
-        id: newTdId,
-        rowspan: 1,
-        colspan: curTd.colspan,
-        value: [
-          {
-            value: ZERO,
-            size: 16,
-            tableId,
-            trId: newTrId,
-            tdId: newTdId
-          }
-        ]
-      })
-    }
-    curTrList.splice(trIndex! + 1, 0, newTr)
-    // 重新设置上下文
-    this.position.setPositionContext({
-      isTable: true,
-      index,
-      trIndex: trIndex! + 1,
-      tdIndex: 0,
-      tdId: newTr.tdList[0].id,
-      trId: newTr.id,
-      tableId: element.id
-    })
-    this.range.setRange(0, 0)
-    // 重新渲染
-    this.draw.render({ curIndex: 0 })
+    const element = this.position.getTableElementByContext(
+      originalElementList,
+      positionContext
+    )!
+    const trList = element.trList!
+    const curTr = trList[trIndex!]
+    const curTd = curTr.tdList[tdIndex!]
+    const rowIndex = curTd.rowIndex! + curTd.rowspan
+    const height = trList[rowIndex]?.height || curTr.height
+    this._insertTableRow(positionContext, element, rowIndex, height)
   }
 
   public adjustColWidth(element: IElement) {
@@ -251,100 +256,84 @@ export class TableOperate {
   public insertTableLeftCol() {
     const positionContext = this.position.getPositionContext()
     if (!positionContext.isTable) return
-    const { index, tdIndex, tableId } = positionContext
+    const { trIndex, tdIndex } = positionContext
     const originalElementList = this.draw.getOriginalElementList()
-    const element = originalElementList[index!]
-    const curTrList = element.trList!
-    const curTdIndex = tdIndex!
-    // 增加列
-    for (let t = 0; t < curTrList.length; t++) {
-      const tr = curTrList[t]
-      const tdId = getUUID()
-      tr.tdList.splice(curTdIndex, 0, {
-        id: tdId,
-        rowspan: 1,
-        colspan: 1,
-        value: [
-          {
-            value: ZERO,
-            size: 16,
-            tableId,
-            trId: tr.id,
-            tdId
-          }
-        ]
-      })
-    }
-    // 重新计算宽度
-    const { defaultColMinWidth } = this.options.table
-    const colgroup = element.colgroup!
-    colgroup.splice(curTdIndex, 0, {
-      width: defaultColMinWidth
-    })
-    this.adjustColWidth(element)
-    // 重新设置上下文
-    this.position.setPositionContext({
-      isTable: true,
-      index,
-      trIndex: 0,
-      tdIndex: curTdIndex,
-      tdId: curTrList[0].tdList[curTdIndex].id,
-      trId: curTrList[0].id,
-      tableId
-    })
-    this.range.setRange(0, 0)
-    // 重新渲染
-    this.draw.render({ curIndex: 0 })
-    this.tableTool.render()
+    const element = this.position.getTableElementByContext(
+      originalElementList,
+      positionContext
+    )!
+    const curTd = element.trList![trIndex!].tdList[tdIndex!]
+    this._insertTableCol(positionContext, element, curTd.colIndex!)
   }
 
   public insertTableRightCol() {
     const positionContext = this.position.getPositionContext()
     if (!positionContext.isTable) return
-    const { index, tdIndex, tableId } = positionContext
+    const { trIndex, tdIndex } = positionContext
     const originalElementList = this.draw.getOriginalElementList()
-    const element = originalElementList[index!]
-    const curTrList = element.trList!
-    const curTdIndex = tdIndex! + 1
-    // 增加列
-    for (let t = 0; t < curTrList.length; t++) {
-      const tr = curTrList[t]
-      const tdId = getUUID()
-      tr.tdList.splice(curTdIndex, 0, {
-        id: tdId,
-        rowspan: 1,
-        colspan: 1,
-        value: [
-          {
-            value: ZERO,
-            size: 16,
-            tableId,
-            trId: tr.id,
-            tdId
-          }
-        ]
-      })
+    const element = this.position.getTableElementByContext(
+      originalElementList,
+      positionContext
+    )!
+    const curTd = element.trList![trIndex!].tdList[tdIndex!]
+    this._insertTableCol(
+      positionContext,
+      element,
+      curTd.colIndex! + curTd.colspan
+    )
+  }
+
+  private _insertTableCol(
+    positionContext: IPositionContext,
+    element: IElement,
+    colIndex: number
+  ) {
+    const trList = element.trList!
+    const spanningTdList: ITd[] = []
+    for (let t = 0; t < trList.length; t++) {
+      const tdList = trList[t].tdList
+      for (let d = 0; d < tdList.length; d++) {
+        const td = tdList[d]
+        if (
+          td.colIndex! < colIndex &&
+          td.colIndex! + td.colspan > colIndex
+        ) {
+          td.colspan++
+          spanningTdList.push(td)
+        }
+      }
     }
-    // 重新计算宽度
+
+    const insertedTdList: ITd[] = []
+    for (let t = 0; t < trList.length; t++) {
+      const spanningTd = spanningTdList.find(
+        td => td.rowIndex! <= t && td.rowIndex! + td.rowspan > t
+      )
+      if (spanningTd) continue
+      const tr = trList[t]
+      const newTd = this._createEmptyTd(element.id, tr.id)
+      let tdIndex = tr.tdList.findIndex(td => td.colIndex! >= colIndex)
+      if (!~tdIndex) tdIndex = tr.tdList.length
+      tr.tdList.splice(tdIndex, 0, newTd)
+      insertedTdList.push(newTd)
+    }
+
     const { defaultColMinWidth } = this.options.table
-    const colgroup = element.colgroup!
-    colgroup.splice(curTdIndex, 0, {
+    element.colgroup!.splice(colIndex, 0, {
       width: defaultColMinWidth
     })
     this.adjustColWidth(element)
-    // 重新设置上下文
-    this.position.setPositionContext({
-      isTable: true,
-      index,
-      trIndex: 0,
-      tdIndex: curTdIndex,
-      tdId: curTrList[0].tdList[curTdIndex].id,
-      trId: curTrList[0].id,
-      tableId: element.id
-    })
+
+    const targetTd =
+      spanningTdList.find(
+        td => td.rowIndex! <= 0 && td.rowIndex! + td.rowspan > 0
+      ) || insertedTdList[0]
+    if (targetTd) {
+      this._setTablePosition(positionContext, element, targetTd)
+    }
     this.range.setRange(0, 0)
-    // 重新渲染
     this.draw.render({ curIndex: 0 })
+    this.tableTool.render()
   }
 
   public deleteTableRow() {

--- a/tests/core/command/table.test.ts
+++ b/tests/core/command/table.test.ts
@@ -7,6 +7,148 @@ import { mergeOption } from '@/editor/utils/option'
 import { formatElementList } from '@/editor/utils/element'
 import { createTestEditor } from '../../factories/editor'
 
+function createComplexTableDraw() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const options = mergeOption({ width: 794, height: 1123 })
+  const main = [
+    {
+      type: 'table' as any,
+      value: '',
+      colgroup: [
+        { width: 100 },
+        { width: 100 },
+        { width: 100 },
+        { width: 100 }
+      ],
+      trList: [
+        {
+          height: 40,
+          tdList: [
+            {
+              colspan: 3,
+              rowspan: 1,
+              value: [{ value: 'header' }]
+            },
+            {
+              colspan: 1,
+              rowspan: 3,
+              value: [{ value: 'detail' }]
+            }
+          ]
+        },
+        {
+          height: 40,
+          tdList: [
+            {
+              colspan: 1,
+              rowspan: 2,
+              value: [{ value: 'anchor' }]
+            },
+            {
+              colspan: 2,
+              rowspan: 1,
+              value: [{ value: 'group' }]
+            }
+          ]
+        },
+        {
+          height: 40,
+          tdList: [
+            {
+              colspan: 1,
+              rowspan: 1,
+              value: [{ value: 'child-b' }]
+            },
+            {
+              colspan: 1,
+              rowspan: 1,
+              value: [{ value: 'child-c' }]
+            }
+          ]
+        },
+        {
+          height: 40,
+          tdList: ['body-a', 'body-b', 'body-c', 'body-d'].map(value => ({
+            colspan: 1,
+            rowspan: 1,
+            value: [{ value }]
+          }))
+        }
+      ]
+    },
+    { value: '\n' }
+  ]
+  formatElementList(main, {
+    editorOptions: options,
+    isForceCompensation: true
+  })
+  const draw = new Draw(
+    container,
+    options,
+    { header: [{ value: '\n' }], main, footer: [{ value: '\n' }] },
+    new Listener(),
+    new EventBus(),
+    new Override()
+  )
+  draw.render()
+  const originalElementList = draw.getOriginalElementList()
+  const tableIndex = originalElementList.findIndex(
+    element => element.type === 'table'
+  )
+  const table = originalElementList[tableIndex] as any
+
+  return {
+    draw,
+    table,
+    tableIndex,
+    destroy: () => {
+      draw.destroy()
+      container.remove()
+    }
+  }
+}
+
+function getTdText(td: any) {
+  return td.value.map((element: any) => element.value).join('')
+}
+
+function getTdByText(table: any, value: string) {
+  for (const tr of table.trList) {
+    const td = tr.tdList.find((item: any) => getTdText(item).includes(value))
+    if (td) return td
+  }
+  throw new Error(`Table cell not found: ${value}`)
+}
+
+function selectTableCell(
+  draw: Draw,
+  table: any,
+  tableIndex: number,
+  value: string
+) {
+  for (let trIndex = 0; trIndex < table.trList.length; trIndex++) {
+    const tr = table.trList[trIndex]
+    const tdIndex = tr.tdList.findIndex((td: any) =>
+      getTdText(td).includes(value)
+    )
+    if (~tdIndex) {
+      const td = tr.tdList[tdIndex]
+      draw.getPosition().setPositionContext({
+        isTable: true,
+        index: tableIndex,
+        trIndex,
+        tdIndex,
+        tdId: td.id,
+        trId: tr.id,
+        tableId: table.id
+      })
+      return
+    }
+  }
+  throw new Error(`Table cell not found: ${value}`)
+}
+
 describe('表格与分隔命令', () => {
   let ctx: ReturnType<typeof createTestEditor>
   afterEach(() => ctx?.destroy())
@@ -243,5 +385,224 @@ describe('表格与分隔命令', () => {
 
     draw.destroy()
     container.remove()
+  })
+
+  it('嵌套表格插列只修改内层表格并保留定位路径', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const options = mergeOption({ width: 794, height: 1123 })
+    const main = [
+      {
+        type: 'table' as any,
+        value: '',
+        colgroup: [{ width: 260 }],
+        trList: [
+          {
+            height: 140,
+            tdList: [
+              {
+                colspan: 1,
+                rowspan: 1,
+                value: [
+                  {
+                    type: 'table' as any,
+                    value: '',
+                    colgroup: [{ width: 100 }, { width: 100 }],
+                    trList: [
+                      {
+                        height: 60,
+                        tdList: [
+                          {
+                            colspan: 1,
+                            rowspan: 1,
+                            value: [{ value: '\n' }, { value: 'A' }]
+                          },
+                          {
+                            colspan: 1,
+                            rowspan: 1,
+                            value: [{ value: '\n' }, { value: 'B' }]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      { value: '\n' }
+    ]
+    formatElementList(main, {
+      editorOptions: options,
+      isForceCompensation: true
+    })
+    const draw = new Draw(
+      container,
+      options,
+      { header: [{ value: '\n' }], main, footer: [{ value: '\n' }] },
+      new Listener(),
+      new EventBus(),
+      new Override()
+    )
+    draw.render()
+
+    const originalElementList = draw.getOriginalElementList()
+    const outerTableIndex = originalElementList.findIndex(
+      (element: any) => element.type === 'table'
+    )
+    const outerTable = originalElementList[outerTableIndex]
+    const outerTd = outerTable.trList![0].tdList[0]
+    const innerTableIndex = outerTd.value.findIndex(
+      (element: any) => element.type === 'table'
+    )
+    const innerTable = outerTd.value[innerTableIndex]
+    const innerFirstTd = innerTable.trList![0].tdList[0]
+    draw.getPosition().setPositionContext({
+      isTable: true,
+      index: outerTableIndex,
+      trIndex: 0,
+      tdIndex: 0,
+      tdId: innerFirstTd.id,
+      trId: innerTable.trList![0].id,
+      tableId: innerTable.id,
+      tablePath: [
+        {
+          index: outerTableIndex,
+          trIndex: 0,
+          tdIndex: 0,
+          tdId: outerTd.id,
+          trId: outerTable.trList![0].id,
+          tableId: outerTable.id
+        },
+        {
+          index: innerTableIndex,
+          trIndex: 0,
+          tdIndex: 0,
+          tdId: innerFirstTd.id,
+          trId: innerTable.trList![0].id,
+          tableId: innerTable.id
+        }
+      ]
+    })
+
+    draw.getTableOperate().insertTableRightCol()
+
+    expect(innerTable.colgroup).toHaveLength(3)
+    expect(outerTable.colgroup).toHaveLength(1)
+    expect(draw.getPosition().getPositionContext().tableId).toBe(innerTable.id)
+    expect(
+      draw.getPosition().getPositionContext().tablePath?.at(-1)?.tableId
+    ).toBe(innerTable.id)
+
+    draw.destroy()
+    container.remove()
+  })
+
+  it('复杂合并表头最右侧插列时保持原单元格逻辑列位置', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'detail')
+
+    draw.getTableOperate().insertTableRightCol()
+
+    expect(table.colgroup).toHaveLength(5)
+    expect(getTdByText(table, 'detail').colIndex).toBe(3)
+    for (let colIndex = 0; colIndex < 4; colIndex++) {
+      expect(getTdByText(table, `body-${'abcd'[colIndex]}`).colIndex).toBe(
+        colIndex
+      )
+    }
+    expect(table.trList[3].tdList).toHaveLength(5)
+    expect(table.trList[3].tdList[4].colIndex).toBe(4)
+
+    destroy()
+  })
+
+  it('插列边界穿过横向合并单元格时扩展 colspan', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'anchor')
+
+    draw.getTableOperate().insertTableRightCol()
+
+    expect(table.colgroup).toHaveLength(5)
+    expect(getTdByText(table, 'header').colspan).toBe(4)
+    expect(getTdByText(table, 'detail').colIndex).toBe(4)
+    expect(getTdByText(table, 'group').colIndex).toBe(2)
+    expect(getTdByText(table, 'body-b').colIndex).toBe(2)
+
+    destroy()
+  })
+
+  it('复杂合并表头左侧插列时使用逻辑列边界', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'body-c')
+
+    draw.getTableOperate().insertTableLeftCol()
+
+    expect(table.colgroup).toHaveLength(5)
+    expect(getTdByText(table, 'header').colspan).toBe(4)
+    expect(getTdByText(table, 'group').colspan).toBe(3)
+    expect(getTdByText(table, 'detail').colIndex).toBe(4)
+    expect(getTdByText(table, 'child-c').colIndex).toBe(3)
+    expect(getTdByText(table, 'body-d').colIndex).toBe(4)
+
+    destroy()
+  })
+
+  it('纵向合并单元格下方插行时按实际行边界新增普通行', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'detail')
+
+    draw.getTableOperate().insertTableBottomRow()
+
+    expect(table.trList).toHaveLength(5)
+    expect(getTdByText(table, 'detail').rowspan).toBe(3)
+    expect(getTdByText(table, 'body-a').rowIndex).toBe(4)
+    expect(table.trList[3].tdList).toHaveLength(4)
+    expect(
+      table.trList[3].tdList.every(
+        (td: any) => td.rowspan === 1 && td.colspan === 1
+      )
+    ).toBe(true)
+
+    destroy()
+  })
+
+  it('复杂合并表头上方插行时新增由普通单元格组成的行', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'header')
+
+    draw.getTableOperate().insertTableTopRow()
+
+    expect(table.trList).toHaveLength(5)
+    expect(table.trList[0].tdList).toHaveLength(4)
+    expect(
+      table.trList[0].tdList.every(
+        (td: any) => td.rowspan === 1 && td.colspan === 1
+      )
+    ).toBe(true)
+    expect(getTdByText(table, 'header').rowIndex).toBe(1)
+
+    destroy()
+  })
+
+  it('插行边界穿过纵向合并单元格时扩展 rowspan', () => {
+    const { draw, table, tableIndex, destroy } = createComplexTableDraw()
+    selectTableCell(draw, table, tableIndex, 'anchor')
+
+    draw.getTableOperate().insertTableTopRow()
+
+    expect(table.trList).toHaveLength(5)
+    expect(getTdByText(table, 'detail').rowspan).toBe(4)
+    expect(getTdByText(table, 'anchor').rowIndex).toBe(2)
+    expect(table.trList[1].tdList).toHaveLength(3)
+    expect(
+      table.trList[1].tdList.every(
+        (td: any) => td.rowspan === 1 && td.colspan === 1
+      )
+    ).toBe(true)
+
+    destroy()
   })
 })


### PR DESCRIPTION
## bug现象
**当表格存在多级嵌套表头时，插入单元格行列会出现单元格错位问题**
**插入前：尝试在最右侧列插入一列**
<img width="1650" height="886" alt="image" src="https://github.com/user-attachments/assets/40dcbd60-79b4-4a2a-8b72-59eda15a8ed3" />
 **插入后：单元格错/内容错位**
<img width="1458" height="877" alt="image" src="https://github.com/user-attachments/assets/64e06f6f-d5dc-409a-b5af-81f2e04b7f37" />

本次提交仅修改 TableOperate.ts 